### PR TITLE
Remove center mark from shared logo

### DIFF
--- a/img/logo.svg
+++ b/img/logo.svg
@@ -7,5 +7,4 @@
   </defs>
   <rect width="32" height="32" rx="7" fill="url(#g)"/>
   <path d="M8 9 L16 23 L24 9" fill="none" stroke="#C7DEC0" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="16" cy="13" r="2.5" fill="#C7DEC0" opacity="0.6"/>
 </svg>


### PR DESCRIPTION
## What changed
- removes the inner circle from the shared `img/logo.svg` asset
- keeps the outer mark and existing gradient styling intact

## Why
- addresses issue #2 requesting the center icon be removed from the existing SVG logo

## Validation
- verified the SVG diff locally
- confirmed the issue branch was pushed to `origin/H33T-issue-2-logo`