### PR TITLE
Improve mobile menu close icon visibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1601,7 +1601,7 @@ noscript + * .fade-in,
   }
 
   body.menu-open .nav-mobile-toggle.active span {
-    background: var(--white);
+    background: var(--primary);
   }
 
   .hero .container {


### PR DESCRIPTION
## What changed
- updates the open-state mobile menu toggle color to use the site green instead of white

## Why
- fixes issue #3 where the close icon was too hard to see against the light header background

## Validation
- verified the CSS change locally
- confirmed the issue branch was pushed to `origin/H33T-issue-3-mobile-menu`