### PR TITLE
Keep footer legal copy on one line

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1087,9 +1087,11 @@ img {
 
 .footer-bottom .footer-legal {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-width: 520px;
+  flex: 1 1 640px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  min-width: 0;
 }
 
 .footer-bottom p {


### PR DESCRIPTION
## What changed
- changes the footer legal section to a wrapping inline flex layout
- keeps the Oasis of Change credit aligned with the rest of the footer legal text

## Why
- fixes issue #5 where the footer credit was dropping onto a separate line

## Validation
- verified the CSS diff locally
- confirmed the issue branch was pushed to `origin/H33T-issue-5-footer-line`