### PR TITLE
Unify publications page into one tagged grid

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -50,8 +50,9 @@
   <section class="home-section publications-index">
     <div class="container">
       <header class="home-section-header">
-        <p class="home-section-kicker">Safety</p>
-        <h2 class="home-section-title">Safety publications</h2>
+        <p class="home-section-kicker">Library</p>
+        <h2 class="home-section-title">All publications</h2>
+        <p class="home-section-lead">Focus area is shown on each card (Safety, Sustainability, or Ethics) alongside topic tags.</p>
       </header>
       <div class="publication-cards-grid">
         <article class="publication-card">
@@ -76,17 +77,6 @@
           <ul class="publication-tags"><li>Operations</li><li>Incident Response</li><li>Monitoring</li></ul>
           <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
-      </div>
-    </div>
-  </section>
-
-  <section class="home-section publications-index">
-    <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Sustainability</p>
-        <h2 class="home-section-title">Sustainability publications</h2>
-      </header>
-      <div class="publication-cards-grid">
         <article class="publication-card">
           <div class="publication-card-meta">
             <span class="publication-pill publication-pill--sustainability">Sustainability</span>
@@ -109,17 +99,6 @@
           <ul class="publication-tags"><li>Reporting</li><li>Standards</li><li>Metrics</li></ul>
           <a class="modern-card-link" href="publications/energy-footprint-reporting-standard.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
-      </div>
-    </div>
-  </section>
-
-  <section class="home-section publications-index">
-    <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Ethics</p>
-        <h2 class="home-section-title">Ethics publications</h2>
-      </header>
-      <div class="publication-cards-grid">
         <article class="publication-card">
           <div class="publication-card-meta">
             <span class="publication-pill publication-pill--ethics">Ethics</span>


### PR DESCRIPTION
## Summary
Implements **#15**: removes separate **Safety / Sustainability / Ethics** section headings on `publications.html` and merges all publication cards into **one** `publication-cards-grid`.

## Details
- Single section with header **Library** / **All publications** and a short lead explaining that focus area appears on each card (existing `publication-pill` + topic tags unchanged).
- Card order unchanged (same six pieces as before: two Safety, two Sustainability, two Ethics).

Closes #15