### PR TITLE
Refresh publications page layout

### DIFF
--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -953,25 +953,18 @@ img { max-width: 100%; height: auto; display: block; }
 
 .pub-card {
   background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  border-top-width: 3px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
   padding: 26px 26px 22px;
   display: flex;
   flex-direction: column;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05), 0 2px 8px rgba(0, 0, 0, 0.04);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
-
-.pub-card--safety        { border-top-color: #10b981; }
-.pub-card--sustainability { border-top-color: #0d9488; }
-.pub-card--ethics        { border-top-color: #3b82f6; }
 
 .pub-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  border-right-color: var(--primary);
-  border-bottom-color: var(--primary);
-  border-left-color: var(--primary);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.06);
 }
 
 .pub-card-meta {

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -860,6 +860,170 @@ img { max-width: 100%; height: auto; display: block; }
   }
 }
 
+/* ─────────────── PUBLICATIONS INDEX (UNIFIED) ─────────────── */
+
+.pub-index {
+  padding: 0 0 100px;
+}
+
+.pub-filter-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 36px 0 40px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 40px;
+  flex-wrap: wrap;
+}
+
+.pub-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-page);
+  border-radius: 999px;
+  padding: 4px;
+}
+
+.pub-tab {
+  background: transparent;
+  border: none;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.pub-tab:hover {
+  color: var(--text-dark);
+}
+
+.pub-tab--active {
+  background: var(--bg-canvas);
+  color: var(--text-dark);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+.pub-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--primary);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 999px;
+}
+
+.pub-tab-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pub-tab-dot--safety        { background: #10b981; }
+.pub-tab-dot--sustainability { background: #0d9488; }
+.pub-tab-dot--ethics        { background: #3b82f6; }
+
+.pub-result-label {
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.pub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+
+.pub-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  border-top-width: 3px;
+  padding: 26px 26px 22px;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.pub-card--safety        { border-top-color: #10b981; }
+.pub-card--sustainability { border-top-color: #0d9488; }
+.pub-card--ethics        { border-top-color: #3b82f6; }
+
+.pub-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  border-right-color: var(--primary);
+  border-bottom-color: var(--primary);
+  border-left-color: var(--primary);
+}
+
+.pub-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 14px;
+}
+
+.pub-card-title {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-dark);
+  letter-spacing: -0.02em;
+  line-height: 1.35;
+  margin-bottom: 10px;
+}
+
+.pub-card-excerpt {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-body);
+  margin-bottom: 16px;
+  flex: 1;
+}
+
+.pub-card--hidden {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .pub-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pub-filter-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .pub-tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+  }
+}
+
 /* ─────────────── RESEARCH DOMAINS ─────────────── */
 
 .research-domains { padding: 80px 0 100px; }

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -48,101 +48,101 @@
     </div>
   </section>
 
-  <section class="home-section publications-index">
+  <section class="pub-index">
     <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Safety</p>
-        <h2 class="home-section-title">Safety publications</h2>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card">
-          <div class="publication-card-meta">
+
+      <div class="pub-filter-bar">
+        <div class="pub-tabs" role="tablist" aria-label="Filter publications by pillar">
+          <button class="pub-tab pub-tab--active" data-filter="all" role="tab" aria-selected="true">
+            All <span class="pub-tab-count">6</span>
+          </button>
+          <button class="pub-tab" data-filter="safety" role="tab" aria-selected="false">
+            <span class="pub-tab-dot pub-tab-dot--safety" aria-hidden="true"></span>Safety
+          </button>
+          <button class="pub-tab" data-filter="sustainability" role="tab" aria-selected="false">
+            <span class="pub-tab-dot pub-tab-dot--sustainability" aria-hidden="true"></span>Sustainability
+          </button>
+          <button class="pub-tab" data-filter="ethics" role="tab" aria-selected="false">
+            <span class="pub-tab-dot pub-tab-dot--ethics" aria-hidden="true"></span>Ethics
+          </button>
+        </div>
+        <p class="pub-result-label" id="pubCount" aria-live="polite">6 publications</p>
+      </div>
+
+      <div class="pub-grid" id="pubGrid">
+
+        <article class="pub-card pub-card--safety" data-pillar="safety">
+          <div class="pub-card-meta">
             <span class="publication-pill publication-pill--safety">Safety</span>
             <span>Mar 15, 2026</span>
             <span>7 min read</span>
           </div>
-          <h3>Practical AI Safety Evaluations for Public-Interest Teams</h3>
-          <p>A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
+          <h3 class="pub-card-title">Practical AI Safety Evaluations for Public-Interest Teams</h3>
+          <p class="pub-card-excerpt">A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
           <ul class="publication-tags"><li>Evaluations</li><li>Risk</li><li>Governance</li></ul>
           <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--safety">Safety</span>
-            <span>Dec 12, 2025</span>
-            <span>5 min read</span>
-          </div>
-          <h3>Incident Reporting Playbook for Responsible AI Teams</h3>
-          <p>A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p>
-          <ul class="publication-tags"><li>Operations</li><li>Incident Response</li><li>Monitoring</li></ul>
-          <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-      </div>
-    </div>
-  </section>
 
-  <section class="home-section publications-index">
-    <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Sustainability</p>
-        <h2 class="home-section-title">Sustainability publications</h2>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card">
-          <div class="publication-card-meta">
+        <article class="pub-card pub-card--sustainability" data-pillar="sustainability">
+          <div class="pub-card-meta">
             <span class="publication-pill publication-pill--sustainability">Sustainability</span>
             <span>Feb 27, 2026</span>
             <span>6 min read</span>
           </div>
-          <h3>A Sustainability Checklist for AI Procurement</h3>
-          <p>How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
+          <h3 class="pub-card-title">A Sustainability Checklist for AI Procurement</h3>
+          <p class="pub-card-excerpt">How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
           <ul class="publication-tags"><li>Climate</li><li>Procurement</li><li>Infrastructure</li></ul>
           <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--sustainability">Sustainability</span>
-            <span>Nov 19, 2025</span>
-            <span>6 min read</span>
-          </div>
-          <h3>Energy Footprint Reporting: A Starter Standard</h3>
-          <p>A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.</p>
-          <ul class="publication-tags"><li>Reporting</li><li>Standards</li><li>Metrics</li></ul>
-          <a class="modern-card-link" href="publications/energy-footprint-reporting-standard.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-      </div>
-    </div>
-  </section>
 
-  <section class="home-section publications-index">
-    <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Ethics</p>
-        <h2 class="home-section-title">Ethics publications</h2>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card">
-          <div class="publication-card-meta">
+        <article class="pub-card pub-card--ethics" data-pillar="ethics">
+          <div class="pub-card-meta">
             <span class="publication-pill publication-pill--ethics">Ethics</span>
             <span>Jan 31, 2026</span>
             <span>8 min read</span>
           </div>
-          <h3>Participatory Ethics in Municipal AI Decisions</h3>
-          <p>Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
+          <h3 class="pub-card-title">Participatory Ethics in Municipal AI Decisions</h3>
+          <p class="pub-card-excerpt">Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
           <ul class="publication-tags"><li>Inclusion</li><li>Policy</li><li>Public Deliberation</li></ul>
           <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
-        <article class="publication-card">
-          <div class="publication-card-meta">
+
+        <article class="pub-card pub-card--safety" data-pillar="safety">
+          <div class="pub-card-meta">
+            <span class="publication-pill publication-pill--safety">Safety</span>
+            <span>Dec 12, 2025</span>
+            <span>5 min read</span>
+          </div>
+          <h3 class="pub-card-title">Incident Reporting Playbook for Responsible AI Teams</h3>
+          <p class="pub-card-excerpt">A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p>
+          <ul class="publication-tags"><li>Operations</li><li>Incident Response</li><li>Monitoring</li></ul>
+          <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
+        </article>
+
+        <article class="pub-card pub-card--sustainability" data-pillar="sustainability">
+          <div class="pub-card-meta">
+            <span class="publication-pill publication-pill--sustainability">Sustainability</span>
+            <span>Nov 19, 2025</span>
+            <span>6 min read</span>
+          </div>
+          <h3 class="pub-card-title">Energy Footprint Reporting: A Starter Standard</h3>
+          <p class="pub-card-excerpt">A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.</p>
+          <ul class="publication-tags"><li>Reporting</li><li>Standards</li><li>Metrics</li></ul>
+          <a class="modern-card-link" href="publications/energy-footprint-reporting-standard.html">Read publication <span aria-hidden="true">→</span></a>
+        </article>
+
+        <article class="pub-card pub-card--ethics" data-pillar="ethics">
+          <div class="pub-card-meta">
             <span class="publication-pill publication-pill--ethics">Ethics</span>
             <span>Oct 28, 2025</span>
             <span>7 min read</span>
           </div>
-          <h3>Human Oversight Design Patterns That Actually Work</h3>
-          <p>Common oversight patterns fail when reviewers are overloaded. These design patterns improve decision quality.</p>
+          <h3 class="pub-card-title">Human Oversight Design Patterns That Actually Work</h3>
+          <p class="pub-card-excerpt">Common oversight patterns fail when reviewers are overloaded. These design patterns improve decision quality.</p>
           <ul class="publication-tags"><li>Human-in-the-loop</li><li>UX</li><li>Accountability</li></ul>
           <a class="modern-card-link" href="publications/human-oversight-design-patterns.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
+
       </div>
     </div>
   </section>
@@ -189,5 +189,38 @@
   </footer>
 
   <script src="js/main.js"></script>
+  <script>
+    (function () {
+      var tabs = document.querySelectorAll('.pub-tab');
+      var cards = document.querySelectorAll('.pub-card');
+      var countEl = document.getElementById('pubCount');
+
+      tabs.forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          var filter = tab.dataset.filter;
+
+          tabs.forEach(function (t) {
+            t.classList.remove('pub-tab--active');
+            t.setAttribute('aria-selected', 'false');
+          });
+          tab.classList.add('pub-tab--active');
+          tab.setAttribute('aria-selected', 'true');
+
+          var visible = 0;
+          cards.forEach(function (card) {
+            var matches = filter === 'all' || card.dataset.pillar === filter;
+            if (matches) {
+              card.classList.remove('pub-card--hidden');
+              visible++;
+            } else {
+              card.classList.add('pub-card--hidden');
+            }
+          });
+
+          countEl.textContent = visible + (visible === 1 ? ' publication' : ' publications');
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -71,7 +71,7 @@
 
       <div class="pub-grid" id="pubGrid">
 
-        <article class="pub-card pub-card--safety" data-pillar="safety">
+        <article class="pub-card" data-pillar="safety">
           <div class="pub-card-meta">
             <span class="publication-pill publication-pill--safety">Safety</span>
             <span>Mar 15, 2026</span>
@@ -83,7 +83,7 @@
           <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
 
-        <article class="pub-card pub-card--sustainability" data-pillar="sustainability">
+        <article class="pub-card" data-pillar="sustainability">
           <div class="pub-card-meta">
             <span class="publication-pill publication-pill--sustainability">Sustainability</span>
             <span>Feb 27, 2026</span>
@@ -95,7 +95,7 @@
           <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
 
-        <article class="pub-card pub-card--ethics" data-pillar="ethics">
+        <article class="pub-card" data-pillar="ethics">
           <div class="pub-card-meta">
             <span class="publication-pill publication-pill--ethics">Ethics</span>
             <span>Jan 31, 2026</span>
@@ -107,7 +107,7 @@
           <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
 
-        <article class="pub-card pub-card--safety" data-pillar="safety">
+        <article class="pub-card" data-pillar="safety">
           <div class="pub-card-meta">
             <span class="publication-pill publication-pill--safety">Safety</span>
             <span>Dec 12, 2025</span>
@@ -119,7 +119,7 @@
           <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
 
-        <article class="pub-card pub-card--sustainability" data-pillar="sustainability">
+        <article class="pub-card" data-pillar="sustainability">
           <div class="pub-card-meta">
             <span class="publication-pill publication-pill--sustainability">Sustainability</span>
             <span>Nov 19, 2025</span>
@@ -131,7 +131,7 @@
           <a class="modern-card-link" href="publications/energy-footprint-reporting-standard.html">Read publication <span aria-hidden="true">→</span></a>
         </article>
 
-        <article class="pub-card pub-card--ethics" data-pillar="ethics">
+        <article class="pub-card" data-pillar="ethics">
           <div class="pub-card-meta">
             <span class="publication-pill publication-pill--ethics">Ethics</span>
             <span>Oct 28, 2025</span>


### PR DESCRIPTION
## What changed
- consolidated the publications listing into a single unified grid
- added pillar filter tabs for `All`, `Safety`, `Sustainability`, and `Ethics`
- introduced new publications page card and filter-bar styling in `dev/css/styles.css`
- added lightweight client-side filtering with a live publication count in `dev/publications.html`
- date sorted order
-

## Why
The previous page split publications into separate stacked sections by pillar. This update makes the page easier to scan, gives visitors a faster way to filter by topic, and creates a more cohesive publications index.

## Impact
- visitors can browse all publications from one view
- filtering is immediate and does not require a page reload
- the page layout is more compact and consistent across pillars

## Validation
- reviewed the HTML/CSS/JS changes locally
- no automated tests were run for this static page update

## screenshots:

<img width="1253" height="797" alt="image" src="https://github.com/user-attachments/assets/4f15f096-a355-45f8-8523-47decc99eac7" />

<img width="615" height="728" alt="full page screenshot" src="https://github.com/user-attachments/assets/0b3f531a-35b1-4c5d-95d0-bc81affe2511" />

