### PR TITLE
Refresh contact page and add research digest band into Main

### DIFF
--- a/dev/about.html
+++ b/dev/about.html
@@ -101,6 +101,23 @@
     </div>
   </section>
 
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/contact.html
+++ b/dev/contact.html
@@ -39,88 +39,146 @@
     </div>
   </nav>
 
-  <section class="page-hero">
-    <div class="container">
-      <div class="page-hero-content">
-        <div class="section-label">REACH OUT</div>
-        <h1 class="page-hero-title">
-          Get in
-          <span class="italic-accent">Touch</span>
-        </h1>
-        <p class="page-hero-description">Whether you're a researcher, policymaker, or prospective collaborator, we'd love to hear from you. Our team is based in Vancouver, BC.</p>
+  <main>
+
+    <!-- Hero block -->
+    <div class="contact2-hero">
+      <div class="container">
+        <div class="contact2-kicker">CONTACT</div>
+        <h1 class="contact2-heading">Have a question?<br><span class="contact2-heading-blue">Let's talk.</span></h1>
+        <p class="contact2-lede">Whether you're a researcher, policymaker, journalist, or prospective partner, our team is based in Vancouver, BC and collaborates globally.</p>
       </div>
-      <div class="page-hero-visual">
-        <div style="display: flex; flex-direction: column; gap: 16px; align-items: flex-end;">
-          <div class="hero-image-card">
-            <img src="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=400&h=260&fit=crop&q=80" alt="Vancouver skyline" loading="lazy">
+    </div>
+
+    <!-- Split card -->
+    <div class="contact2-split-section">
+      <div class="container">
+        <div class="contact2-card">
+
+          <!-- Left: skyline panel -->
+          <div class="contact2-skyline" role="img" aria-label="Vancouver skyline">
+            <div class="contact2-coord">
+              <span class="contact2-coord-dot"></span>
+              <span>49.2827° N, 123.1207° W</span>
+            </div>
+            <div class="contact2-skyline-bottom">
+              <p class="contact2-skyline-kicker">OUR HOME</p>
+              <p class="contact2-skyline-coord-mobile">49.28° N · 123.12° W</p>
+              <h2 class="contact2-skyline-heading">Vancouver,<br>British Columbia</h2>
+              <div class="contact2-skyline-meta">
+                <div class="contact2-skyline-meta-cell">
+                  <span class="contact2-skyline-meta-label">Email</span>
+                  <span class="contact2-skyline-meta-value">info@vcasse.org</span>
+                </div>
+                <div class="contact2-skyline-meta-cell">
+                  <span class="contact2-skyline-meta-label">Hours</span>
+                  <span class="contact2-skyline-meta-value">Mon–Fri · 09:00–17:00 PT</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right: form -->
+          <div class="contact2-form-col">
+            <p class="contact2-form-kicker">SEND A MESSAGE</p>
+            <h2 class="contact2-form-title">Tell us about your inquiry.</h2>
+            <form action="#" method="POST">
+              <div class="contact2-name-row">
+                <div class="contact2-field">
+                  <div class="contact2-field-label">
+                    <label for="c2-firstName">First name</label>
+                  </div>
+                  <input class="contact2-input" type="text" id="c2-firstName" name="firstName" placeholder="Jane" required>
+                </div>
+                <div class="contact2-field">
+                  <div class="contact2-field-label">
+                    <label for="c2-lastName">Last name</label>
+                  </div>
+                  <input class="contact2-input" type="text" id="c2-lastName" name="lastName" placeholder="Doe" required>
+                </div>
+              </div>
+              <div class="contact2-field">
+                <div class="contact2-field-label">
+                  <label for="c2-email">Email</label>
+                </div>
+                <input class="contact2-input" type="email" id="c2-email" name="email" placeholder="jane@example.com" required>
+              </div>
+              <div class="contact2-field">
+                <div class="contact2-field-label">
+                  <label for="c2-org">Organization</label>
+                  <span class="contact2-field-optional">Optional</span>
+                </div>
+                <input class="contact2-input" type="text" id="c2-org" name="organization" placeholder="UBC, City of Vancouver, etc." aria-label="Organization (optional)">
+              </div>
+              <div class="contact2-field">
+                <div class="contact2-field-label">
+                  <label for="c2-topic">Topic</label>
+                </div>
+                <select class="contact2-select" id="c2-topic" name="topic">
+                  <option value="" disabled selected>Select a topic…</option>
+                  <option value="research">Research collaboration</option>
+                  <option value="partnership">Partnership</option>
+                  <option value="media">Media inquiry</option>
+                  <option value="general">General question</option>
+                </select>
+              </div>
+              <div class="contact2-field">
+                <div class="contact2-field-label">
+                  <label for="c2-message">Message</label>
+                </div>
+                <textarea class="contact2-textarea" id="c2-message" name="message" placeholder="Share a few details…" required></textarea>
+              </div>
+              <div class="contact2-form-footer">
+                <button type="submit" class="contact2-submit">
+                  Send message
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+                </button>
+              </div>
+            </form>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <!-- Directory strip -->
+    <div class="contact2-directory-section">
+      <div class="container">
+        <div class="contact2-directory">
+          <div class="contact2-dir-card">
+            <p class="contact2-dir-kicker">01 / RESPONSE TIME</p>
+            <p class="contact2-dir-value">Within two business days</p>
+            <p class="contact2-dir-sub">Mon–Fri, Pacific Time</p>
+          </div>
+          <div class="contact2-dir-card">
+            <p class="contact2-dir-kicker">02 / MEDIA & PRESS</p>
+            <p class="contact2-dir-value">press@vcasse.org</p>
+            <p class="contact2-dir-sub">Interviews, commentary, embargoed briefs</p>
+          </div>
+          <div class="contact2-dir-card">
+            <p class="contact2-dir-kicker">03 / RESEARCH PARTNERSHIPS</p>
+            <p class="contact2-dir-value">collaborate@vcasse.org</p>
+            <p class="contact2-dir-sub">Grants, visiting scholars, joint papers</p>
           </div>
         </div>
       </div>
     </div>
-  </section>
 
-  <section class="research-domains">
+  </main>
+
+
+  <section class="digest-band">
     <div class="container">
-      <div class="contact-grid">
-        <div class="contact-info">
-          <h3>Contact Information</h3>
-          <p>Whether you're a researcher, policymaker, journalist, or prospective partner, we'd love to hear from you. Our team is based in Vancouver, BC and collaborates globally.</p>
-
-          <div class="contact-detail">
-            <div class="contact-detail-icon">
-              <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
-            </div>
-            <div>
-              <h4>Email</h4>
-              <p>info@vcasse.org</p>
-            </div>
-          </div>
-
-          <div class="contact-detail">
-            <div class="contact-detail-icon">
-              <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-            </div>
-            <div>
-              <h4>Address</h4>
-              <p>Vancouver, BC<br>Canada</p>
-            </div>
-          </div>
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
         </div>
-
-        <div class="contact-form">
-          <h3 style="font-size: 20px; font-weight: 700; color: var(--text-dark); margin-bottom: 24px;">Send a Message</h3>
-          <form action="#" method="POST">
-            <div class="form-row">
-              <div class="form-group">
-                <label for="firstName">First Name</label>
-                <input type="text" id="firstName" name="firstName" placeholder="Jane" required>
-              </div>
-              <div class="form-group">
-                <label for="lastName">Last Name</label>
-                <input type="text" id="lastName" name="lastName" placeholder="Doe" required>
-              </div>
-            </div>
-            <div class="form-group">
-              <label for="email">Email Address</label>
-              <input type="email" id="email" name="email" placeholder="jane@example.com" required>
-            </div>
-            <div class="form-group">
-              <label for="subject">Subject</label>
-              <select id="subject" name="subject">
-                <option value="">Select a topic...</option>
-                <option value="research">Research Collaboration</option>
-                <option value="partnership">Partnership</option>
-                <option value="media">Media Inquiry</option>
-                <option value="general">General Question</option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label for="message">Message</label>
-              <textarea id="message" name="message" placeholder="Tell us about your inquiry..." required></textarea>
-            </div>
-            <button type="submit" class="btn btn-primary" style="width: 100%;">Send Message</button>
-          </form>
-        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
       </div>
     </div>
   </section>

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -2118,3 +2118,500 @@ noscript + * .fade-in,
     .nav-links > li { transition-duration: .01ms !important; transition-delay: 0s !important; }
   }
 }
+
+/* ─────────────── CONTACT PAGE (v2) ─────────────── */
+
+.contact2-hero {
+  background: #ffffff;
+  padding: 64px 0 40px;
+}
+
+.contact2-kicker {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  color: var(--primary);
+  margin-bottom: 14px;
+}
+
+.contact2-heading {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 72px;
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+  color: var(--text-dark);
+  max-width: 900px;
+  margin: 0;
+}
+
+.contact2-heading-blue { color: var(--primary); }
+
+.contact2-lede {
+  font-family: var(--font-sans);
+  font-size: 17px;
+  line-height: 1.65;
+  color: var(--text-body);
+  max-width: 560px;
+  margin-top: 24px;
+}
+
+/* Split card */
+.contact2-split-section {
+  background: #ffffff;
+  padding: 40px 0 96px;
+}
+
+.contact2-card {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  background: #ffffff;
+  min-height: 640px;
+}
+
+/* Skyline panel */
+.contact2-skyline {
+  background-image:
+    linear-gradient(180deg, rgba(5,26,46,0.15) 0%, rgba(5,26,46,0.45) 100%),
+    url('https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=1200&h=1600&fit=crop&q=80');
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 40px;
+  color: #ffffff;
+}
+
+.contact2-coord {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.82);
+}
+
+.contact2-coord-dot {
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green-accent);
+  box-shadow: 0 0 0 4px rgba(108,180,228,0.25);
+  flex-shrink: 0;
+}
+
+.contact2-skyline-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 12px;
+}
+
+.contact2-skyline-coord-mobile {
+  display: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 8px;
+}
+
+.contact2-skyline-heading {
+  font-family: var(--font-display);
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: #ffffff;
+  margin-bottom: 20px;
+}
+
+.contact2-skyline-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  border-top: 1px solid rgba(255,255,255,0.2);
+  padding-top: 20px;
+}
+
+.contact2-skyline-meta-cell {
+  display: flex;
+  flex-direction: column;
+}
+
+.contact2-skyline-meta-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.65);
+  margin-bottom: 6px;
+}
+
+.contact2-skyline-meta-value {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: #ffffff;
+}
+
+/* Form column */
+.contact2-form-col {
+  padding: 56px 48px;
+}
+
+.contact2-form-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 14px;
+}
+
+.contact2-form-title {
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text-dark);
+  margin: 0 0 36px;
+}
+
+/* Field primitive */
+.contact2-field { margin-bottom: 16px; }
+
+.contact2-field-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+}
+
+.contact2-field-label label {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dark);
+  letter-spacing: 0.02em;
+}
+
+.contact2-field-optional {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-light);
+}
+
+.contact2-input,
+.contact2-select,
+.contact2-textarea {
+  width: 100%;
+  padding: 14px 16px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-dark);
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.contact2-input::placeholder,
+.contact2-textarea::placeholder { color: var(--text-light); }
+
+.contact2-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
+  padding-right: 40px;
+  cursor: pointer;
+}
+
+.contact2-input:focus,
+.contact2-select:focus,
+.contact2-textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(13,79,139,0.1);
+}
+
+.contact2-textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.contact2-name-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.contact2-form-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.contact2-submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--primary);
+  color: #ffffff;
+  padding: 16px 32px;
+  border-radius: 4px;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.contact2-submit:hover { background: var(--primary-light); }
+
+.contact2-submit:focus-visible {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
+/* Directory strip */
+.contact2-directory-section {
+  background: #ffffff;
+  padding: 0 0 96px;
+}
+
+.contact2-directory {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.contact2-dir-card {
+  background: var(--bg-light);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 24px 24px 22px;
+}
+
+.contact2-dir-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--primary);
+  margin-bottom: 10px;
+}
+
+.contact2-dir-value {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 4px;
+}
+
+.contact2-dir-sub {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* ─────────────── DIGEST BAND (sitewide) ─────────────── */
+
+.digest-band {
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
+  padding: 72px 0;
+}
+
+.digest-band-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 48px;
+}
+
+.digest-band-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  color: var(--primary);
+  margin-bottom: 12px;
+}
+
+.digest-band-heading {
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--text-dark);
+  margin: 0 0 10px;
+  max-width: 420px;
+}
+
+.digest-band-sub {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-muted);
+  max-width: 400px;
+  margin: 0;
+}
+
+.digest-band-form {
+  display: flex;
+  gap: 0;
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: #ffffff;
+  box-shadow: var(--shadow-sm);
+}
+
+.digest-band-input {
+  padding: 14px 18px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-dark);
+  background: transparent;
+  border: none;
+  outline: none;
+  width: 260px;
+}
+
+.digest-band-input::placeholder { color: var(--text-light); }
+
+.digest-band-input:focus { box-shadow: inset 0 0 0 2px var(--primary); }
+
+.digest-band-submit {
+  padding: 14px 24px;
+  background: var(--primary);
+  color: #ffffff;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.digest-band-submit:hover { background: var(--primary-light); }
+
+.digest-band-submit:focus-visible {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
+@media (max-width: 1024px) {
+  .digest-band-inner { gap: 32px; }
+  .digest-band-heading { font-size: 24px; }
+}
+
+@media (max-width: 767px) {
+  .digest-band { padding: 48px 0; }
+  .digest-band-inner { flex-direction: column; align-items: flex-start; gap: 28px; }
+  .digest-band-heading { font-size: 22px; }
+  .digest-band-form { width: 100%; }
+  .digest-band-input { width: 100%; flex: 1; }
+}
+
+/* ─── CONTACT PAGE (v2) RESPONSIVE ─── */
+
+@media (max-width: 1024px) {
+  .contact2-heading { font-size: clamp(44px, 6vw, 64px); }
+
+  .contact2-card {
+    gap: 32px;
+    min-height: 520px;
+  }
+
+  .contact2-form-col { padding: 40px 32px; }
+
+  .contact2-directory { gap: 12px; }
+}
+
+@media (max-width: 767px) {
+  .contact2-hero { padding: 40px 0 28px; }
+  .contact2-hero .container { padding: 0 20px; }
+
+  .contact2-heading { font-size: 40px; line-height: 1; }
+  .contact2-lede { font-size: 15px; }
+
+  .contact2-split-section { padding: 28px 0 0; }
+  .contact2-split-section .container { padding: 0; }
+
+  .contact2-card {
+    display: block;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    min-height: 0;
+  }
+
+  .contact2-skyline {
+    height: 220px;
+    border-radius: 12px;
+    margin: 0 20px;
+    padding: 20px;
+  }
+
+  .contact2-coord { display: none; }
+  .contact2-skyline-kicker { display: none; }
+  .contact2-skyline-coord-mobile { display: block; }
+  .contact2-skyline-meta { display: none; }
+
+  .contact2-skyline-heading {
+    font-size: 22px;
+    margin-bottom: 0;
+  }
+
+  .contact2-form-col {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    margin: 28px 20px 48px;
+  }
+
+  .contact2-form-kicker { font-size: 10px; }
+  .contact2-form-title { font-size: 22px; }
+
+  .contact2-name-row { grid-template-columns: 1fr; }
+
+  .contact2-form-footer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .contact2-submit { width: 100%; justify-content: center; }
+
+  .contact2-directory-section { padding: 0 0 48px; }
+  .contact2-directory-section .container { padding: 0 20px; }
+
+  .contact2-directory { grid-template-columns: 1fr; }
+  .contact2-dir-card { padding: 16px; }
+}

--- a/dev/ethics.html
+++ b/dev/ethics.html
@@ -129,6 +129,23 @@
   </section>
 
   <!-- FOOTER -->
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/events.html
+++ b/dev/events.html
@@ -127,6 +127,23 @@
     </div>
   </section>
 
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/index.html
+++ b/dev/index.html
@@ -189,6 +189,23 @@
   </section>
 
   <!-- FOOTER -->
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/privacy.html
+++ b/dev/privacy.html
@@ -107,6 +107,23 @@
     </p>
   </div>
 
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -147,6 +147,23 @@
     </div>
   </section>
 
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/safety.html
+++ b/dev/safety.html
@@ -125,6 +125,23 @@
   </section>
 
   <!-- FOOTER -->
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/sustainability.html
+++ b/dev/sustainability.html
@@ -125,6 +125,23 @@
   </section>
 
   <!-- FOOTER -->
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">

--- a/dev/terms.html
+++ b/dev/terms.html
@@ -92,6 +92,23 @@
     </p>
   </div>
 
+
+  <section class="digest-band">
+    <div class="container">
+      <div class="digest-band-inner">
+        <div class="digest-band-copy">
+          <p class="digest-band-kicker">RESEARCH DIGEST</p>
+          <h2 class="digest-band-heading">Stay informed on AI policy and research.</h2>
+          <p class="digest-band-sub">Quarterly updates from VCASSE — policy briefs, new research, and upcoming events. No spam, unsubscribe anytime.</p>
+        </div>
+        <form class="digest-band-form" action="#" method="POST">
+          <input class="digest-band-input" type="email" name="digest_email" placeholder="your@email.com" required aria-label="Email address">
+          <button class="digest-band-submit" type="submit">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
   <footer class="footer">
     <div class="container">
       <div class="footer-main">


### PR DESCRIPTION
## What changed
- redesigned the contact page with a new hero, split layout, updated inquiry form, and directory-style support details
- added a reusable research digest subscription band above the footer
- inserted the new digest band across the main site pages so the footer call-to-action is consistent everywhere
- added the supporting styles for the new contact layout and digest component in `dev/css/styles.css`

## Why
The contact page needed a stronger first impression and a more intentional inquiry flow. The new layout makes the page feel more editorial and structured, while the digest band creates a consistent site-wide call-to-action for ongoing engagement.

## Impact
- visitors get a clearer contact experience with a more polished visual hierarchy
- the site now has a shared pre-footer subscription strip across pages
- footer-adjacent engagement is more consistent throughout the site

## Validation
- reviewed the HTML and CSS changes locally
- no automated tests were run for this static site update

## Notes
- this branch was recreated from `main` so the PR only includes the contact-page and digest-band work

## Screenshots
-
<img width="622" height="802" alt="image" src="https://github.com/user-attachments/assets/40150037-83fe-4d5a-92da-541396ffb294" />


-
<img width="622" height="443" alt="image" src="https://github.com/user-attachments/assets/b4fcb42b-7017-4d97-bc0c-7a17d95f1f18" />
