### PR TITLE
Build out publications and contact pages

### DIFF
--- a/dev/contact.html
+++ b/dev/contact.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contact | VCASSE</title>
+  <meta name="description" content="Get in touch with the Vancouver Centre for AI Safety, Sustainability, and Ethics.">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="icon" type="image/svg+xml" href="img/logo.svg">
 </head>
@@ -47,13 +48,16 @@
           Get in
           <span class="italic-accent">Touch</span>
         </h1>
-        <p class="page-hero-description">Whether you're a researcher, policymaker, or prospective collaborator, we'd love to hear from you. Our team is based in Vancouver, BC.</p>
+        <p class="page-hero-description">Whether you're a researcher, policymaker, journalist, or prospective collaborator, we'd love to hear from you. Our team is based in Vancouver, BC and collaborates globally.</p>
+        <ul class="page-hero-quicklinks" aria-label="Quick contact options">
+          <li><a href="#contact-form">Send a message</a></li>
+          <li><a href="mailto:info@vcasse.org">Email us</a></li>
+          <li><a href="#contact-faq">FAQ</a></li>
+        </ul>
       </div>
       <div class="page-hero-visual">
-        <div style="display: flex; flex-direction: column; gap: 16px; align-items: flex-end;">
-          <div class="hero-image-card">
-            <img src="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=400&h=260&fit=crop&q=80" alt="Vancouver skyline" loading="lazy">
-          </div>
+        <div class="hero-image-card">
+          <img src="https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=400&h=260&fit=crop&q=80" alt="Vancouver skyline" loading="lazy">
         </div>
       </div>
     </div>
@@ -63,16 +67,36 @@
     <div class="container">
       <div class="contact-grid">
         <div class="contact-info">
-          <h3>Contact Information</h3>
-          <p>Whether you're a researcher, policymaker, journalist, or prospective partner, we'd love to hear from you. Our team is based in Vancouver, BC and collaborates globally.</p>
+          <h3>Contact information</h3>
+          <p>We read every message. Most enquiries get a first response within two business days. Time-sensitive media requests are flagged for same-day reply.</p>
 
           <div class="contact-detail">
             <div class="contact-detail-icon">
               <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
             </div>
             <div>
-              <h4>Email</h4>
-              <p>info@vcasse.org</p>
+              <h4>General &amp; partnerships</h4>
+              <p><a href="mailto:info@vcasse.org">info@vcasse.org</a></p>
+            </div>
+          </div>
+
+          <div class="contact-detail">
+            <div class="contact-detail-icon">
+              <svg viewBox="0 0 24 24"><path d="M12 1a4 4 0 0 0-4 4v6a4 4 0 0 0 8 0V5a4 4 0 0 0-4-4zm6 10a6 6 0 0 1-12 0H4a8 8 0 0 0 7 7.93V22h2v-3.07A8 8 0 0 0 20 11h-2z"/></svg>
+            </div>
+            <div>
+              <h4>Media enquiries</h4>
+              <p><a href="mailto:media@vcasse.org">media@vcasse.org</a> &middot; same-day response when possible</p>
+            </div>
+          </div>
+
+          <div class="contact-detail">
+            <div class="contact-detail-icon">
+              <svg viewBox="0 0 24 24"><path d="M21 7l-9 6L3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7zm-9 4l9-6H3l9 6z"/></svg>
+            </div>
+            <div>
+              <h4>Research collaborations</h4>
+              <p><a href="mailto:research@vcasse.org">research@vcasse.org</a> &middot; safety, sustainability, ethics</p>
             </div>
           </div>
 
@@ -81,46 +105,110 @@
               <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
             </div>
             <div>
-              <h4>Address</h4>
-              <p>Vancouver, BC<br>Canada</p>
+              <h4>Where we work</h4>
+              <p>Vancouver, BC &middot; on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
             </div>
+          </div>
+
+          <div class="contact-info-card">
+            <p class="contact-info-card-kicker">Office hours</p>
+            <p class="contact-info-card-line">Mon &ndash; Fri &middot; 9:00 &ndash; 17:00 PT</p>
+            <p class="contact-info-card-meta">Closed on statutory holidays. Public events are listed on the <a href="events.html">events page</a>.</p>
           </div>
         </div>
 
-        <div class="contact-form">
-          <h3 style="font-size: 20px; font-weight: 700; color: var(--text-dark); margin-bottom: 24px;">Send a Message</h3>
+        <div class="contact-form" id="contact-form">
+          <h3 class="contact-form-title">Send a message</h3>
+          <p class="contact-form-lede">Tell us a little about why you're reaching out. We'll route your message to the right person on our team.</p>
           <form action="#" method="POST">
             <div class="form-row">
               <div class="form-group">
-                <label for="firstName">First Name</label>
+                <label for="firstName">First name</label>
                 <input type="text" id="firstName" name="firstName" placeholder="Jane" required>
               </div>
               <div class="form-group">
-                <label for="lastName">Last Name</label>
+                <label for="lastName">Last name</label>
                 <input type="text" id="lastName" name="lastName" placeholder="Doe" required>
               </div>
             </div>
             <div class="form-group">
-              <label for="email">Email Address</label>
+              <label for="email">Email address</label>
               <input type="email" id="email" name="email" placeholder="jane@example.com" required>
             </div>
             <div class="form-group">
-              <label for="subject">Subject</label>
-              <select id="subject" name="subject">
-                <option value="">Select a topic...</option>
-                <option value="research">Research Collaboration</option>
-                <option value="partnership">Partnership</option>
-                <option value="media">Media Inquiry</option>
-                <option value="general">General Question</option>
+              <label for="organization">Organization <span class="form-optional">(optional)</span></label>
+              <input type="text" id="organization" name="organization" placeholder="e.g. City of Vancouver">
+            </div>
+            <div class="form-group">
+              <label for="subject">What is this about?</label>
+              <select id="subject" name="subject" required>
+                <option value="">Select a topic&hellip;</option>
+                <option value="research">Research collaboration</option>
+                <option value="partnership">Partnership or sponsorship</option>
+                <option value="policy">Policy &amp; government</option>
+                <option value="media">Media enquiry</option>
+                <option value="speaking">Speaking request</option>
+                <option value="general">General question</option>
               </select>
             </div>
             <div class="form-group">
               <label for="message">Message</label>
-              <textarea id="message" name="message" placeholder="Tell us about your inquiry..." required></textarea>
+              <textarea id="message" name="message" placeholder="Tell us about your enquiry&hellip;" required></textarea>
             </div>
-            <button type="submit" class="btn btn-primary" style="width: 100%;">Send Message</button>
+            <p class="contact-form-privacy">By sending, you agree to our <a href="privacy.html">privacy policy</a>. We never share your email.</p>
+            <button type="submit" class="btn btn-primary contact-form-submit">Send message</button>
           </form>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="contact-faq" id="contact-faq" aria-labelledby="contact-faq-heading">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">FAQ</p>
+        <h2 id="contact-faq-heading" class="home-section-title">Common questions</h2>
+        <p class="home-section-lead">Quick answers before you write &mdash; if anything here doesn't fit your situation, please send us a message.</p>
+      </header>
+      <div class="contact-faq-list">
+        <details class="contact-faq-item" open>
+          <summary>How quickly will I get a reply?</summary>
+          <p>Most enquiries receive a first response within two business days. Media enquiries are flagged for same-day attention when possible.</p>
+        </details>
+        <details class="contact-faq-item">
+          <summary>Can VCASSE speak at our event or panel?</summary>
+          <p>Yes &mdash; we accept speaking requests across safety, sustainability, and ethics topics. Use the form above and select <em>Speaking request</em>, and please include the date, format, and audience.</p>
+        </details>
+        <details class="contact-faq-item">
+          <summary>How do I propose a research collaboration?</summary>
+          <p>Reach out via <a href="mailto:research@vcasse.org">research@vcasse.org</a> with a short note describing the question, the data or partner involved, and the timeline. We'll set up a 30-minute scoping call.</p>
+        </details>
+        <details class="contact-faq-item">
+          <summary>Are you taking on student researchers or interns?</summary>
+          <p>We work with student researchers from Vancouver-area universities on a rolling basis. Send your CV and a paragraph on what you'd like to work on.</p>
+        </details>
+        <details class="contact-faq-item">
+          <summary>Where can I read your published work?</summary>
+          <p>All briefs, explainers, and research notes are on the <a href="publications.html">publications page</a>, filterable by pillar, tag, and date.</p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications, upcoming public panels, and plain-language notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();" aria-describedby="newsletter-soon-note">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note" id="newsletter-soon-note">Sign-ups open soon &mdash; we're still setting things up.</p>
+        </form>
       </div>
     </div>
   </section>

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -2118,3 +2118,923 @@ noscript + * .fade-in,
     .nav-links > li { transition-duration: .01ms !important; transition-delay: 0s !important; }
   }
 }
+
+/* ─────────────── ACCESSIBILITY HELPERS ─────────────── */
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ─────────────── PUBLICATIONS INDEX PAGE ─────────────── */
+
+.publications-hero .container {
+  align-items: center;
+}
+
+.publications-hero-visual {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.publications-hero-stat-card {
+  background: var(--bg-dark);
+  color: rgba(226, 232, 240, 0.85);
+  border-radius: 18px;
+  padding: 28px 28px 24px;
+  width: 100%;
+  max-width: 320px;
+  box-shadow: 0 18px 40px -22px rgba(8, 42, 77, 0.55);
+  border: 1px solid rgba(108, 180, 228, 0.2);
+}
+
+.publications-hero-stat {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.publications-hero-stat-num {
+  font-family: var(--font-display);
+  font-size: 56px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--white);
+  letter-spacing: -0.04em;
+}
+
+.publications-hero-stat-label {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(207, 226, 243, 0.7);
+}
+
+.publications-hero-pillars {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid rgba(207, 226, 243, 0.15);
+  padding-top: 14px;
+  margin: 0 0 14px;
+}
+
+.publications-hero-pillars li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: rgba(207, 226, 243, 0.75);
+}
+
+.publications-hero-pillars .publication-pill {
+  border: 1px solid transparent;
+}
+
+.publications-hero-note {
+  font-size: 12px;
+  color: rgba(207, 226, 243, 0.6);
+  margin: 0;
+  line-height: 1.55;
+}
+
+.publications-toolbar-section {
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 22px 0;
+}
+
+.publications-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.publications-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.publications-toolbar-row--dense {
+  gap: 18px;
+}
+
+.publication-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 0;
+}
+
+.publication-filter--safety.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--white);
+}
+
+.publication-filter--sustainability.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--white);
+}
+
+.publication-filter--ethics.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--white);
+}
+
+.publications-search {
+  position: relative;
+  flex: 1 1 260px;
+  min-width: 220px;
+  max-width: 420px;
+}
+
+.publications-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.publications-search input {
+  width: 100%;
+  padding: 11px 14px 11px 40px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-card);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--text-dark);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.publications-search input::placeholder {
+  color: var(--text-light);
+}
+
+.publications-search input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(13, 79, 139, 0.12);
+}
+
+.publications-select-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.publications-select-group label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.publications-select-group select {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-dark);
+  cursor: pointer;
+}
+
+.publications-count {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.publications-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.publication-card--with-cover {
+  padding: 0;
+  overflow: hidden;
+}
+
+.publication-card-cover {
+  position: relative;
+  display: block;
+  aspect-ratio: 16 / 9;
+  background: var(--bg-dark);
+  overflow: hidden;
+}
+
+.publication-card-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.publication-card--with-cover:hover .publication-card-cover img {
+  transform: scale(1.04);
+}
+
+.publication-card-cover .publication-pill {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(4px);
+}
+
+.publication-card-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 22px;
+}
+
+.publication-card-body h3 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-dark);
+  letter-spacing: -0.02em;
+  margin-bottom: 10px;
+  line-height: 1.3;
+}
+
+.publication-card-body h3 a {
+  color: inherit;
+}
+
+.publication-card-body h3 a:hover {
+  color: var(--primary);
+}
+
+.publication-card-body p {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-body);
+  margin-bottom: 14px;
+}
+
+.publication-card-authors {
+  font-size: 12px !important;
+  color: var(--text-muted) !important;
+  margin-top: -6px;
+  margin-bottom: 14px !important;
+}
+
+.publications-empty {
+  text-align: center;
+  padding: 64px 24px;
+  background: var(--bg-light);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.publications-empty h3 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 8px;
+}
+
+.publications-empty p {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+
+/* ─────────────── PUBLICATION DETAIL PAGE ─────────────── */
+
+.publication-detail-hero {
+  background: linear-gradient(165deg, var(--bg-dark) 0%, var(--primary-dark) 60%, var(--primary) 130%);
+  color: var(--white);
+  padding: 64px 0 72px;
+  position: relative;
+  overflow: hidden;
+}
+
+.publication-detail-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+  background-size: 22px 22px;
+  pointer-events: none;
+}
+
+.publication-detail-hero .container {
+  position: relative;
+  z-index: 1;
+}
+
+.publication-detail-crumb {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(207, 226, 243, 0.7);
+  margin-bottom: 28px;
+}
+
+.publication-detail-crumb a {
+  color: rgba(207, 226, 243, 0.9);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.publication-detail-crumb a:hover {
+  color: var(--white);
+}
+
+.publication-detail-crumb span[aria-hidden="true"] {
+  margin: 0 8px;
+  opacity: 0.5;
+}
+
+.publication-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 56px;
+  align-items: center;
+}
+
+.publication-detail-text .publication-pill {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--white);
+  border-color: rgba(255, 255, 255, 0.3);
+  margin-bottom: 18px;
+}
+
+.publication-detail-text h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  color: var(--white);
+  margin-bottom: 20px;
+}
+
+.publication-detail-lede {
+  font-size: 17px;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.85);
+  margin-bottom: 28px;
+  max-width: 560px;
+}
+
+.publication-detail-meta {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, auto));
+  gap: 24px;
+  padding: 0;
+  margin: 0;
+}
+
+.publication-detail-meta li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.publication-detail-meta li span {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(207, 226, 243, 0.55);
+}
+
+.publication-detail-meta li strong {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--white);
+}
+
+.publication-detail-cover {
+  margin: 0;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 60px -28px rgba(0, 0, 0, 0.55);
+  aspect-ratio: 16 / 9;
+}
+
+.publication-detail-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.publication-body {
+  padding: 80px 0 64px;
+}
+
+.publication-body-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+  gap: 56px;
+  align-items: start;
+}
+
+.publication-prose h2 {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--text-dark);
+  letter-spacing: -0.01em;
+  margin: 36px 0 14px;
+}
+
+.publication-prose ol,
+.publication-prose ul {
+  margin: 0 0 22px 1.2rem;
+  padding: 0;
+}
+
+.publication-prose ol li,
+.publication-prose ul li {
+  font-size: 16px;
+  line-height: 1.75;
+  color: var(--text-body);
+  margin-bottom: 8px;
+}
+
+.publication-prose strong {
+  color: var(--text-dark);
+}
+
+.publication-pull {
+  margin: 36px 0;
+  padding: 24px 28px;
+  border-left: 3px solid var(--primary);
+  background: var(--bg-light);
+  border-radius: 0 12px 12px 0;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-style: italic;
+  color: var(--text-dark);
+  line-height: 1.55;
+}
+
+.publication-aside {
+  position: sticky;
+  top: calc(var(--nav-height) + 24px);
+  display: grid;
+  gap: 18px;
+}
+
+.publication-aside-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 22px;
+  box-shadow: 0 12px 30px -22px rgba(8, 42, 77, 0.18);
+}
+
+.publication-aside-card h3 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin: 0 0 14px;
+}
+
+.publication-aside-card ul {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.publication-aside-card ul li {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-body);
+  margin-bottom: 8px;
+}
+
+.publication-aside-card--tags ul {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.publication-aside-card--tags ul li {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--bg-page);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  margin: 0;
+}
+
+.publications-related {
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
+}
+
+/* ─────────────── NEWSLETTER COMING SOON ─────────────── */
+
+.newsletter-band {
+  padding: 72px 0;
+}
+
+.newsletter-card {
+  background: linear-gradient(160deg, var(--bg-dark) 0%, var(--primary-dark) 60%, var(--primary) 130%);
+  color: var(--white);
+  border-radius: 22px;
+  padding: 48px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 40px;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 30px 60px -32px rgba(8, 42, 77, 0.55);
+}
+
+.newsletter-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 22px 22px;
+  pointer-events: none;
+}
+
+.newsletter-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.newsletter-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(207, 226, 243, 0.75);
+  margin-bottom: 12px;
+}
+
+.newsletter-soon {
+  display: inline-block;
+  padding: 3px 8px;
+  border: 1px solid var(--green-accent);
+  color: var(--green-accent);
+  border-radius: 999px;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  margin-left: 4px;
+}
+
+.newsletter-content h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.75rem, 3vw, 2.4rem);
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--white);
+  margin-bottom: 12px;
+}
+
+.newsletter-lede {
+  font-size: 15px;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.78);
+  margin: 0;
+}
+
+.newsletter-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.newsletter-form input {
+  grid-column: 1 / 2;
+  padding: 14px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  outline: none;
+  cursor: not-allowed;
+}
+
+.newsletter-form input::placeholder {
+  color: rgba(207, 226, 243, 0.55);
+}
+
+.newsletter-form .btn {
+  grid-column: 2 / 3;
+  padding: 14px 24px;
+  border-radius: 999px;
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.newsletter-form .btn:disabled,
+.newsletter-form input:disabled {
+  pointer-events: none;
+}
+
+.newsletter-note {
+  grid-column: 1 / -1;
+  margin: 4px 0 0;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: rgba(207, 226, 243, 0.65);
+}
+
+/* ─────────────── CONTACT PAGE EXTRAS ─────────────── */
+
+.page-hero-quicklinks {
+  list-style: none;
+  margin: 24px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+}
+
+.page-hero-quicklinks a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-card);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-dark);
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.page-hero-quicklinks a:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.contact-info-card {
+  margin-top: 28px;
+  background: var(--bg-light);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 22px;
+}
+
+.contact-info-card-kicker {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin: 0 0 6px !important;
+}
+
+.contact-info-card-line {
+  font-family: var(--font-display);
+  font-size: 16px !important;
+  font-weight: 600;
+  color: var(--text-dark) !important;
+  margin: 0 0 6px !important;
+}
+
+.contact-info-card-meta {
+  font-size: 13px !important;
+  color: var(--text-muted) !important;
+  margin: 0 !important;
+}
+
+.contact-form-title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-dark);
+  letter-spacing: -0.01em;
+  margin-bottom: 6px;
+}
+
+.contact-form-lede {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-muted);
+  margin-bottom: 22px;
+}
+
+.form-optional {
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 12px;
+}
+
+.contact-form-privacy {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: -4px 0 16px;
+}
+
+.contact-form-privacy a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.contact-form-submit {
+  width: 100%;
+}
+
+/* ─────────────── CONTACT FAQ ─────────────── */
+
+.contact-faq {
+  background: var(--bg-light);
+  border-top: 1px solid var(--border);
+  padding: 80px 0;
+}
+
+.contact-faq-list {
+  display: grid;
+  gap: 14px;
+  max-width: 820px;
+}
+
+.contact-faq-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 22px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-faq-item[open] {
+  border-color: rgba(13, 79, 139, 0.4);
+  box-shadow: 0 12px 26px -22px rgba(8, 42, 77, 0.35);
+}
+
+.contact-faq-item summary {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-dark);
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  letter-spacing: -0.01em;
+}
+
+.contact-faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.contact-faq-item summary::after {
+  content: '+';
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 300;
+  color: var(--primary);
+  transition: transform 0.25s ease;
+}
+
+.contact-faq-item[open] summary::after {
+  transform: rotate(45deg);
+}
+
+.contact-faq-item p {
+  margin: 12px 0 0;
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text-body);
+}
+
+.contact-faq-item p a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* ─────────────── PUBLICATIONS RESPONSIVE ─────────────── */
+
+@media (max-width: 1024px) {
+  .publications-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .publication-detail-grid {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+  .publication-detail-cover {
+    max-width: 520px;
+  }
+  .publication-body-grid {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+  .publication-aside {
+    position: static;
+  }
+  .publications-hero .container {
+    grid-template-columns: 1fr;
+  }
+  .publications-hero-visual {
+    justify-content: flex-start;
+  }
+  .newsletter-card {
+    grid-template-columns: 1fr;
+    padding: 36px;
+  }
+}
+
+@media (max-width: 768px) {
+  .publications-grid {
+    grid-template-columns: 1fr;
+  }
+  .publications-toolbar-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .publications-toolbar-row--dense {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .publications-search {
+    max-width: none;
+  }
+  .publication-filters {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 4px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .publications-count {
+    margin-left: 0;
+    width: 100%;
+  }
+  .publication-detail-hero {
+    padding: 48px 0 56px;
+  }
+  .publication-detail-meta {
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  .publication-body {
+    padding: 56px 0 40px;
+  }
+  .newsletter-card {
+    padding: 28px;
+    border-radius: 18px;
+  }
+  .newsletter-form {
+    grid-template-columns: 1fr;
+  }
+  .newsletter-form .btn {
+    grid-column: 1 / -1;
+  }
+  .contact-faq {
+    padding: 56px 0;
+  }
+  .page-hero-quicklinks {
+    margin-top: 16px;
+  }
+}

--- a/dev/img/publications/energy-footprint.svg
+++ b/dev/img/publications/energy-footprint.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Bar chart representing an energy footprint reporting standard">
+  <defs>
+    <linearGradient id="energy-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#082a4d"/>
+      <stop offset="1" stop-color="#0d4f8b"/>
+    </linearGradient>
+    <linearGradient id="energy-bar" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0" stop-color="#6cb4e4" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#6cb4e4"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#energy-bg)"/>
+  <g stroke="rgba(207,226,243,0.12)" stroke-width="1">
+    <line x1="420" y1="120" x2="760" y2="120"/>
+    <line x1="420" y1="180" x2="760" y2="180"/>
+    <line x1="420" y1="240" x2="760" y2="240"/>
+    <line x1="420" y1="300" x2="760" y2="300"/>
+    <line x1="420" y1="360" x2="760" y2="360"/>
+  </g>
+  <g fill="url(#energy-bar)">
+    <rect x="440" y="260" width="34" height="100" rx="6"/>
+    <rect x="488" y="200" width="34" height="160" rx="6"/>
+    <rect x="536" y="230" width="34" height="130" rx="6"/>
+    <rect x="584" y="150" width="34" height="210" rx="6"/>
+    <rect x="632" y="180" width="34" height="180" rx="6"/>
+    <rect x="680" y="130" width="34" height="230" rx="6"/>
+  </g>
+  <g fill="none" stroke="#cfe2f3" stroke-width="2" stroke-linecap="round">
+    <path d="M440 245 Q505 200 570 215 T750 150"/>
+  </g>
+  <g fill="#cfe2f3">
+    <circle cx="440" cy="245" r="4"/>
+    <circle cx="750" cy="150" r="5"/>
+  </g>
+  <g transform="translate(56 76)" font-family="'IBM Plex Mono', monospace" fill="#cfe2f3" font-size="12" letter-spacing="3">
+    <text y="0" opacity="0.65">VCASSE / SUSTAINABILITY</text>
+    <text y="22" opacity="0.4">REPORTING · STANDARD</text>
+  </g>
+  <g transform="translate(56 220)" fill="#ffffff" font-family="'IBM Plex Sans', 'Inter', sans-serif">
+    <text font-size="32" font-weight="600" letter-spacing="-0.5">Measure.</text>
+    <text y="42" font-size="32" font-weight="600" letter-spacing="-0.5">Disclose.</text>
+    <text y="84" font-size="32" font-weight="600" letter-spacing="-0.5" fill="#6cb4e4">Improve.</text>
+  </g>
+</svg>

--- a/dev/img/publications/human-oversight.svg
+++ b/dev/img/publications/human-oversight.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Abstract eye and review flow representing human oversight">
+  <defs>
+    <linearGradient id="oversight-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#082a4d"/>
+      <stop offset="1" stop-color="#1a6db5"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#oversight-bg)"/>
+  <g fill="none" stroke="rgba(207,226,243,0.2)" stroke-width="1">
+    <path d="M-40 370 Q200 260 420 360 T860 330"/>
+    <path d="M-40 410 Q200 310 420 400 T860 380"/>
+  </g>
+  <g transform="translate(440 140)" fill="none" stroke="#cfe2f3" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 80 Q120 -20 240 80 Q120 180 0 80 Z"/>
+    <circle cx="120" cy="80" r="30" stroke="#6cb4e4"/>
+    <circle cx="120" cy="80" r="10" fill="#6cb4e4" stroke="none"/>
+  </g>
+  <g transform="translate(440 290)" fill="none" stroke="#6cb4e4" stroke-width="1.8" stroke-linecap="round">
+    <line x1="0" y1="0" x2="240" y2="0" opacity="0.4"/>
+    <circle cx="40" cy="0" r="4" fill="#6cb4e4" stroke="none"/>
+    <circle cx="120" cy="0" r="6" fill="#cfe2f3" stroke="none"/>
+    <circle cx="200" cy="0" r="4" fill="#6cb4e4" stroke="none"/>
+  </g>
+  <g transform="translate(56 76)" font-family="'IBM Plex Mono', monospace" fill="#cfe2f3" font-size="12" letter-spacing="3">
+    <text y="0" opacity="0.65">VCASSE / ETHICS</text>
+    <text y="22" opacity="0.4">DESIGN · OVERSIGHT</text>
+  </g>
+  <g transform="translate(56 220)" fill="#ffffff" font-family="'IBM Plex Sans', 'Inter', sans-serif">
+    <text font-size="32" font-weight="600" letter-spacing="-0.5">Human review</text>
+    <text y="42" font-size="32" font-weight="600" letter-spacing="-0.5">that</text>
+    <text y="84" font-size="32" font-weight="600" letter-spacing="-0.5" fill="#6cb4e4">holds up</text>
+  </g>
+</svg>

--- a/dev/img/publications/incident-reporting.svg
+++ b/dev/img/publications/incident-reporting.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Abstract signal waveform representing incident reporting">
+  <defs>
+    <linearGradient id="incident-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#051a2e"/>
+      <stop offset="0.6" stop-color="#082a4d"/>
+      <stop offset="1" stop-color="#0d4f8b"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#incident-bg)"/>
+  <g stroke="rgba(108,180,228,0.18)" stroke-width="1">
+    <line x1="0" y1="90" x2="800" y2="90"/>
+    <line x1="0" y1="180" x2="800" y2="180"/>
+    <line x1="0" y1="270" x2="800" y2="270"/>
+    <line x1="0" y1="360" x2="800" y2="360"/>
+  </g>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M40 300 L120 300 L150 260 L190 340 L230 210 L275 360 L320 290 L360 300 L440 300 L475 220 L520 380 L565 140 L615 360 L665 300 L760 300"
+          stroke="#6cb4e4" stroke-width="3" opacity="0.9"/>
+    <path d="M40 320 L200 320 L230 310 L280 340 L340 320 L400 320 L450 310 L510 340 L580 320 L760 320"
+          stroke="rgba(207,226,243,0.4)" stroke-width="1.5"/>
+  </g>
+  <g fill="#6cb4e4">
+    <circle cx="565" cy="140" r="6"/>
+    <circle cx="520" cy="380" r="4" opacity="0.7"/>
+    <circle cx="275" cy="360" r="4" opacity="0.7"/>
+  </g>
+  <g transform="translate(56 76)" font-family="'IBM Plex Mono', ui-monospace, monospace" fill="#cfe2f3" font-size="12" letter-spacing="3">
+    <text y="0" opacity="0.65">VCASSE / SAFETY</text>
+    <text y="22" opacity="0.4">PLAYBOOK · INCIDENTS</text>
+  </g>
+  <g transform="translate(56 200)" fill="#ffffff" font-family="'IBM Plex Sans', 'Inter', sans-serif">
+    <text font-size="32" font-weight="600" letter-spacing="-0.5">Report · Escalate</text>
+    <text y="42" font-size="32" font-weight="600" letter-spacing="-0.5" fill="#6cb4e4">Learn</text>
+  </g>
+</svg>

--- a/dev/img/publications/participatory-ethics.svg
+++ b/dev/img/publications/participatory-ethics.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Network of connected nodes representing participatory ethics">
+  <defs>
+    <linearGradient id="part-eth-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#051a2e"/>
+      <stop offset="1" stop-color="#0d4f8b"/>
+    </linearGradient>
+    <radialGradient id="part-eth-halo" cx="0.7" cy="0.45" r="0.55">
+      <stop offset="0" stop-color="#cfe2f3" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#cfe2f3" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#part-eth-bg)"/>
+  <rect width="800" height="450" fill="url(#part-eth-halo)"/>
+  <g stroke="rgba(207,226,243,0.35)" stroke-width="1" fill="none">
+    <line x1="560" y1="110" x2="460" y2="225"/>
+    <line x1="560" y1="110" x2="660" y2="175"/>
+    <line x1="460" y1="225" x2="660" y2="175"/>
+    <line x1="460" y1="225" x2="520" y2="340"/>
+    <line x1="660" y1="175" x2="720" y2="290"/>
+    <line x1="520" y1="340" x2="720" y2="290"/>
+    <line x1="520" y1="340" x2="400" y2="320"/>
+    <line x1="400" y1="320" x2="460" y2="225"/>
+    <line x1="460" y1="225" x2="720" y2="290"/>
+  </g>
+  <g>
+    <circle cx="560" cy="110" r="14" fill="#6cb4e4"/>
+    <circle cx="460" cy="225" r="18" fill="#cfe2f3"/>
+    <circle cx="660" cy="175" r="12" fill="#6cb4e4" opacity="0.8"/>
+    <circle cx="520" cy="340" r="14" fill="#cfe2f3" opacity="0.85"/>
+    <circle cx="720" cy="290" r="10" fill="#6cb4e4" opacity="0.7"/>
+    <circle cx="400" cy="320" r="9" fill="#cfe2f3" opacity="0.6"/>
+  </g>
+  <g fill="none" stroke="#6cb4e4" stroke-width="1.6" opacity="0.6">
+    <circle cx="460" cy="225" r="32"/>
+  </g>
+  <g transform="translate(56 76)" font-family="'IBM Plex Mono', monospace" fill="#cfe2f3" font-size="12" letter-spacing="3">
+    <text y="0" opacity="0.65">VCASSE / ETHICS</text>
+    <text y="22" opacity="0.4">PARTICIPATION · POLICY</text>
+  </g>
+  <g transform="translate(56 210)" fill="#ffffff" font-family="'IBM Plex Sans', 'Inter', sans-serif">
+    <text font-size="32" font-weight="600" letter-spacing="-0.5">Residents at</text>
+    <text y="42" font-size="32" font-weight="600" letter-spacing="-0.5">the decision</text>
+    <text y="84" font-size="32" font-weight="600" letter-spacing="-0.5" fill="#6cb4e4">table</text>
+  </g>
+</svg>

--- a/dev/img/publications/safety-evaluations.svg
+++ b/dev/img/publications/safety-evaluations.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Abstract shield composed of concentric evaluation rings">
+  <defs>
+    <linearGradient id="safety-eval-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#082a4d"/>
+      <stop offset="0.55" stop-color="#0d4f8b"/>
+      <stop offset="1" stop-color="#1a6db5"/>
+    </linearGradient>
+    <radialGradient id="safety-eval-glow" cx="0.72" cy="0.3" r="0.7">
+      <stop offset="0" stop-color="#6cb4e4" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#6cb4e4" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#safety-eval-bg)"/>
+  <rect width="800" height="450" fill="url(#safety-eval-glow)"/>
+  <g fill="none" stroke="rgba(207,226,243,0.28)" stroke-width="1.4">
+    <circle cx="560" cy="225" r="60"/>
+    <circle cx="560" cy="225" r="110"/>
+    <circle cx="560" cy="225" r="170"/>
+    <circle cx="560" cy="225" r="240"/>
+  </g>
+  <g stroke="#6cb4e4" stroke-width="2" fill="none" stroke-linecap="round">
+    <path d="M560 105 L560 345"/>
+    <path d="M440 225 L680 225"/>
+  </g>
+  <g fill="#cfe2f3">
+    <circle cx="560" cy="105" r="5"/>
+    <circle cx="560" cy="345" r="5"/>
+    <circle cx="440" cy="225" r="5"/>
+    <circle cx="680" cy="225" r="5"/>
+  </g>
+  <g transform="translate(72 78)" font-family="'IBM Plex Mono', ui-monospace, monospace" fill="#cfe2f3" font-size="12" letter-spacing="3">
+    <text y="0" opacity="0.65">VCASSE / SAFETY</text>
+    <text y="22" opacity="0.4">PUBLICATION · 01</text>
+  </g>
+  <g transform="translate(72 210)" fill="#ffffff" font-family="'IBM Plex Sans', 'Inter', sans-serif">
+    <text font-size="34" font-weight="600" letter-spacing="-0.5">Evaluations</text>
+    <text y="44" font-size="34" font-weight="600" letter-spacing="-0.5">for civic AI</text>
+  </g>
+  <g transform="translate(72 332)" stroke="#6cb4e4" stroke-width="1.2">
+    <line x1="0" y1="0" x2="140" y2="0"/>
+  </g>
+  <g transform="translate(72 354)" fill="rgba(255,255,255,0.6)" font-family="'IBM Plex Mono', monospace" font-size="11" letter-spacing="1.5">
+    <text>RISK · GOVERNANCE · TRUST</text>
+  </g>
+</svg>

--- a/dev/img/publications/sustainability-procurement.svg
+++ b/dev/img/publications/sustainability-procurement.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" role="img" aria-label="Layered tiles representing a procurement checklist">
+  <defs>
+    <linearGradient id="sust-proc-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#082a4d"/>
+      <stop offset="1" stop-color="#0d4f8b"/>
+    </linearGradient>
+    <linearGradient id="sust-proc-accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6cb4e4"/>
+      <stop offset="1" stop-color="#a8d3ec"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#sust-proc-bg)"/>
+  <g fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="1">
+    <path d="M0 360 Q200 320 400 360 T800 360"/>
+    <path d="M0 400 Q200 360 400 400 T800 400"/>
+  </g>
+  <g transform="translate(440 80)" stroke="rgba(207,226,243,0.5)" stroke-width="1.2" fill="none">
+    <rect x="0" y="0" width="300" height="54" rx="10"/>
+    <rect x="0" y="70" width="300" height="54" rx="10"/>
+    <rect x="0" y="140" width="300" height="54" rx="10"/>
+    <rect x="0" y="210" width="300" height="54" rx="10"/>
+  </g>
+  <g transform="translate(440 80)">
+    <g fill="#6cb4e4">
+      <circle cx="30" cy="27" r="10"/>
+      <circle cx="30" cy="97" r="10"/>
+      <circle cx="30" cy="167" r="10" opacity="0.45"/>
+      <circle cx="30" cy="237" r="10" opacity="0.45"/>
+    </g>
+    <g stroke="#082a4d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <path d="M24 27 l4 5 l8 -9"/>
+      <path d="M24 97 l4 5 l8 -9"/>
+    </g>
+    <g fill="rgba(255,255,255,0.9)" font-family="'IBM Plex Mono', monospace" font-size="13" letter-spacing="2">
+      <text x="56" y="32">ENERGY DISCLOSURE</text>
+      <text x="56" y="102">LIFECYCLE IMPACT</text>
+      <text x="56" y="172" opacity="0.55">SUPPLIER TRANSPARENCY</text>
+      <text x="56" y="242" opacity="0.55">END-OF-LIFE PLAN</text>
+    </g>
+  </g>
+  <g transform="translate(56 76)" font-family="'IBM Plex Mono', monospace" fill="#cfe2f3" font-size="12" letter-spacing="3">
+    <text y="0" opacity="0.65">VCASSE / SUSTAINABILITY</text>
+    <text y="22" opacity="0.4">CHECKLIST · PROCUREMENT</text>
+  </g>
+  <g transform="translate(56 220)" fill="#ffffff" font-family="'IBM Plex Sans', 'Inter', sans-serif">
+    <text font-size="32" font-weight="600" letter-spacing="-0.5">Better</text>
+    <text y="42" font-size="32" font-weight="600" letter-spacing="-0.5">vendor</text>
+    <text y="84" font-size="32" font-weight="600" letter-spacing="-0.5" fill="url(#sust-proc-accent)">questions</text>
+  </g>
+</svg>

--- a/dev/js/publications-data.js
+++ b/dev/js/publications-data.js
@@ -1,60 +1,82 @@
 window.VCASSE_PUBLICATIONS = [
   {
+    slug: 'safety-evaluations-public-interest',
     title: 'Practical AI Safety Evaluations for Public-Interest Teams',
     pillar: 'safety',
     tags: ['Evaluations', 'Risk', 'Governance'],
     date: '2026-03-15',
     readingTime: '7 min read',
+    authors: ['Dr. Mei Tanaka', 'Priya Sandhu'],
     excerpt: 'A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.',
+    cover: 'img/publications/safety-evaluations.svg',
     url: 'publications/safety-evaluations-public-interest.html'
   },
   {
+    slug: 'incident-reporting-playbook',
     title: 'Incident Reporting Playbook for Responsible AI Teams',
     pillar: 'safety',
     tags: ['Operations', 'Incident Response', 'Monitoring'],
     date: '2025-12-12',
     readingTime: '5 min read',
+    authors: ['Priya Sandhu'],
     excerpt: 'A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.',
+    cover: 'img/publications/incident-reporting.svg',
     url: 'publications/incident-reporting-playbook.html'
   },
   {
+    slug: 'sustainability-procurement-checklist',
     title: 'A Sustainability Checklist for AI Procurement',
     pillar: 'sustainability',
     tags: ['Climate', 'Procurement', 'Infrastructure'],
     date: '2026-02-27',
     readingTime: '6 min read',
+    authors: ['Dr. Alejandro Ruiz', 'Linh Nguyen'],
     excerpt: 'How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.',
+    cover: 'img/publications/sustainability-procurement.svg',
     url: 'publications/sustainability-procurement-checklist.html'
   },
   {
+    slug: 'energy-footprint-reporting-standard',
     title: 'Energy Footprint Reporting: A Starter Standard',
     pillar: 'sustainability',
     tags: ['Reporting', 'Standards', 'Metrics'],
     date: '2025-11-19',
     readingTime: '6 min read',
+    authors: ['Dr. Alejandro Ruiz'],
     excerpt: 'A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.',
+    cover: 'img/publications/energy-footprint.svg',
     url: 'publications/energy-footprint-reporting-standard.html'
   },
   {
+    slug: 'participatory-ethics-municipal-ai',
     title: 'Participatory Ethics in Municipal AI Decisions',
     pillar: 'ethics',
     tags: ['Inclusion', 'Policy', 'Public Deliberation'],
     date: '2026-01-31',
     readingTime: '8 min read',
+    authors: ['Dr. Amara Okafor', 'Jordan Blackwood'],
     excerpt: 'Why public-facing AI decisions should include structured resident participation, not only internal review.',
+    cover: 'img/publications/participatory-ethics.svg',
     url: 'publications/participatory-ethics-municipal-ai.html'
   },
   {
+    slug: 'human-oversight-design-patterns',
     title: 'Human Oversight Design Patterns That Actually Work',
     pillar: 'ethics',
     tags: ['Human-in-the-loop', 'UX', 'Accountability'],
     date: '2025-10-28',
     readingTime: '7 min read',
+    authors: ['Dr. Amara Okafor'],
     excerpt: 'Common oversight patterns fail when reviewers are overloaded. These design patterns improve decision quality.',
+    cover: 'img/publications/human-oversight.svg',
     url: 'publications/human-oversight-design-patterns.html'
   }
 ];
 
 window.getPublications = function getPublications() {
   return [...window.VCASSE_PUBLICATIONS].sort((a, b) => new Date(b.date) - new Date(a.date));
+};
+
+window.getPublicationBySlug = function getPublicationBySlug(slug) {
+  return window.VCASSE_PUBLICATIONS.find((post) => post.slug === slug) || null;
 };

--- a/dev/js/publications-page.js
+++ b/dev/js/publications-page.js
@@ -1,0 +1,194 @@
+(function () {
+  'use strict';
+
+  const PILLAR_LABELS = {
+    safety: 'Safety',
+    sustainability: 'Sustainability',
+    ethics: 'Ethics'
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const grid = document.getElementById('publicationsGrid');
+    if (!grid || typeof window.getPublications !== 'function') return;
+
+    const posts = window.getPublications();
+    updateHeroStats(posts);
+    const filterButtons = Array.from(document.querySelectorAll('[data-pub-filter]'));
+    const tagSelect = document.getElementById('publicationsTag');
+    const sortSelect = document.getElementById('publicationsSort');
+    const searchInput = document.getElementById('publicationsSearch');
+    const resultsCount = document.getElementById('publicationsCount');
+    const emptyState = document.getElementById('publicationsEmpty');
+    const resetBtn = document.getElementById('publicationsReset');
+
+    const state = { pillar: 'all', tag: 'all', sort: 'newest', query: '' };
+
+    populateTags(tagSelect, posts);
+    render();
+
+    filterButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        state.pillar = btn.getAttribute('data-pub-filter');
+        filterButtons.forEach((b) => b.classList.toggle('active', b === btn));
+        filterButtons.forEach((b) => b.setAttribute('aria-pressed', String(b === btn)));
+        render();
+      });
+    });
+
+    if (tagSelect) {
+      tagSelect.addEventListener('change', () => {
+        state.tag = tagSelect.value;
+        render();
+      });
+    }
+
+    if (sortSelect) {
+      sortSelect.addEventListener('change', () => {
+        state.sort = sortSelect.value;
+        render();
+      });
+    }
+
+    if (searchInput) {
+      let timer;
+      searchInput.addEventListener('input', () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+          state.query = searchInput.value.trim().toLowerCase();
+          render();
+        }, 120);
+      });
+    }
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        state.pillar = 'all';
+        state.tag = 'all';
+        state.sort = 'newest';
+        state.query = '';
+        if (searchInput) searchInput.value = '';
+        if (tagSelect) tagSelect.value = 'all';
+        if (sortSelect) sortSelect.value = 'newest';
+        filterButtons.forEach((b) => {
+          const isAll = b.getAttribute('data-pub-filter') === 'all';
+          b.classList.toggle('active', isAll);
+          b.setAttribute('aria-pressed', String(isAll));
+        });
+        render();
+      });
+    }
+
+    function populateTags(select, list) {
+      if (!select) return;
+      const tags = new Set();
+      list.forEach((p) => p.tags.forEach((t) => tags.add(t)));
+      const sorted = Array.from(tags).sort((a, b) => a.localeCompare(b));
+      sorted.forEach((tag) => {
+        const opt = document.createElement('option');
+        opt.value = tag;
+        opt.textContent = tag;
+        select.appendChild(opt);
+      });
+    }
+
+    function render() {
+      const filtered = posts.filter((post) => {
+        if (state.pillar !== 'all' && post.pillar !== state.pillar) return false;
+        if (state.tag !== 'all' && !post.tags.includes(state.tag)) return false;
+        if (state.query) {
+          const haystack = [post.title, post.excerpt, post.tags.join(' '), (post.authors || []).join(' ')]
+            .join(' ')
+            .toLowerCase();
+          if (!haystack.includes(state.query)) return false;
+        }
+        return true;
+      });
+
+      filtered.sort((a, b) => {
+        if (state.sort === 'oldest') return new Date(a.date) - new Date(b.date);
+        if (state.sort === 'az') return a.title.localeCompare(b.title);
+        return new Date(b.date) - new Date(a.date);
+      });
+
+      grid.innerHTML = '';
+      filtered.forEach((post) => grid.appendChild(buildCard(post)));
+
+      if (resultsCount) {
+        const total = posts.length;
+        const shown = filtered.length;
+        resultsCount.textContent = shown === total
+          ? `Showing all ${total} publications`
+          : `Showing ${shown} of ${total} publications`;
+      }
+
+      if (emptyState) {
+        emptyState.hidden = filtered.length > 0;
+      }
+      grid.hidden = filtered.length === 0;
+    }
+
+    function updateHeroStats(list) {
+      const total = list.length;
+      const heroCount = document.getElementById('publicationsHeroCount');
+      if (heroCount) heroCount.textContent = String(total);
+      const pillarCounts = list.reduce((acc, p) => {
+        acc[p.pillar] = (acc[p.pillar] || 0) + 1;
+        return acc;
+      }, {});
+      document.querySelectorAll('.publications-hero-pillars li').forEach((li) => {
+        const pill = li.querySelector('.publication-pill');
+        if (!pill) return;
+        const key = ['safety', 'sustainability', 'ethics'].find((k) => pill.classList.contains(`publication-pill--${k}`));
+        const valueEl = li.querySelector('span:last-child');
+        if (key && valueEl) valueEl.textContent = String(pillarCounts[key] || 0);
+      });
+    }
+
+    function buildCard(post) {
+      const article = document.createElement('article');
+      article.className = 'publication-card publication-card--with-cover';
+      article.setAttribute('data-pillar', post.pillar);
+
+      const pillarLabel = PILLAR_LABELS[post.pillar] || post.pillar;
+      const dateText = formatDate(post.date);
+      const tags = post.tags.map((t) => `<li>${escapeHtml(t)}</li>`).join('');
+      const authors = (post.authors || []).join(', ');
+
+      article.innerHTML = `
+        <a class="publication-card-cover" href="${post.url}" aria-label="Read ${escapeHtml(post.title)}">
+          <img src="${post.cover}" alt="" loading="lazy" decoding="async">
+          <span class="publication-pill publication-pill--${post.pillar}">${pillarLabel}</span>
+        </a>
+        <div class="publication-card-body">
+          <div class="publication-card-meta">
+            <span>${dateText}</span>
+            <span aria-hidden="true">·</span>
+            <span>${escapeHtml(post.readingTime)}</span>
+          </div>
+          <h3><a href="${post.url}">${escapeHtml(post.title)}</a></h3>
+          <p>${escapeHtml(post.excerpt)}</p>
+          ${authors ? `<p class="publication-card-authors">By ${escapeHtml(authors)}</p>` : ''}
+          <ul class="publication-tags">${tags}</ul>
+          <a class="modern-card-link" href="${post.url}">Read publication <span aria-hidden="true">→</span></a>
+        </div>
+      `;
+      return article;
+    }
+  });
+
+  function formatDate(dateISO) {
+    return new Date(dateISO).toLocaleDateString('en-CA', {
+      year: 'numeric', month: 'short', day: 'numeric'
+    });
+  }
+
+  function escapeHtml(value) {
+    if (value == null) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+})();

--- a/dev/js/publications-related.js
+++ b/dev/js/publications-related.js
@@ -3,30 +3,47 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!containers.length || typeof window.getPublications !== 'function') return;
 
   const allPosts = window.getPublications();
+  const PILLAR_LABELS = {
+    safety: 'Safety',
+    sustainability: 'Sustainability',
+    ethics: 'Ethics'
+  };
 
   containers.forEach((container) => {
     const pillar = (container.getAttribute('data-pillar') || '').toLowerCase();
     const limit = Number(container.getAttribute('data-limit') || 2);
+    const exclude = container.getAttribute('data-exclude') || '';
+    const baseHref = container.getAttribute('data-base-href') || '../';
     if (!pillar) return;
 
-    const posts = allPosts.filter((post) => post.pillar === pillar).slice(0, limit);
-    container.innerHTML = '';
+    const posts = allPosts
+      .filter((post) => post.pillar === pillar && post.slug !== exclude)
+      .slice(0, limit);
 
+    container.innerHTML = '';
     posts.forEach((post) => {
       const card = document.createElement('article');
-      card.className = 'publication-card publication-card--compact';
+      card.className = 'publication-card publication-card--with-cover publication-card--compact';
+      const url = baseHref + post.url;
+      const cover = baseHref + post.cover;
       card.innerHTML = `
-        <div class="publication-card-meta">
-          <span class="publication-pill publication-pill--${post.pillar}">${titleCase(post.pillar)}</span>
-          <span>${formatDate(post.date)}</span>
-          <span>${post.readingTime}</span>
+        <a class="publication-card-cover" href="${url}" aria-label="Read ${escapeHtml(post.title)}">
+          <img src="${cover}" alt="" loading="lazy" decoding="async">
+          <span class="publication-pill publication-pill--${post.pillar}">${PILLAR_LABELS[post.pillar] || post.pillar}</span>
+        </a>
+        <div class="publication-card-body">
+          <div class="publication-card-meta">
+            <span>${formatDate(post.date)}</span>
+            <span aria-hidden="true">·</span>
+            <span>${escapeHtml(post.readingTime)}</span>
+          </div>
+          <h3><a href="${url}">${escapeHtml(post.title)}</a></h3>
+          <p>${escapeHtml(post.excerpt)}</p>
+          <ul class="publication-tags">
+            ${post.tags.map((tag) => `<li>${escapeHtml(tag)}</li>`).join('')}
+          </ul>
+          <a class="modern-card-link" href="${url}">Read publication <span aria-hidden="true">→</span></a>
         </div>
-        <h3>${post.title}</h3>
-        <p>${post.excerpt}</p>
-        <ul class="publication-tags">
-          ${post.tags.map((tag) => `<li>${tag}</li>`).join('')}
-        </ul>
-        <a class="modern-card-link" href="${post.url}">Read publication <span aria-hidden="true">→</span></a>
       `;
       container.appendChild(card);
     });
@@ -41,6 +58,12 @@ function formatDate(dateISO) {
   });
 }
 
-function titleCase(value) {
-  return value.charAt(0).toUpperCase() + value.slice(1);
+function escapeHtml(value) {
+  if (value == null) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Publications | VCASSE</title>
+  <meta name="description" content="Policy briefs, explainers, and research notes from VCASSE across AI safety, sustainability, and ethics.">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="icon" type="image/svg+xml" href="img/logo.svg">
 </head>
@@ -38,111 +39,94 @@
     </div>
   </nav>
 
-  <section class="page-hero">
+  <section class="page-hero publications-hero">
     <div class="container">
       <div class="page-hero-content">
         <div class="section-label">PUBLICATIONS</div>
-        <h1 class="page-hero-title">Policy Briefs, Explainers, and Research Notes</h1>
-        <p class="page-hero-description">VCASSE publishes across Safety, Sustainability, and Ethics to support public understanding, policymaker decision-making, and accountable AI development.</p>
+        <h1 class="page-hero-title">
+          Policy briefs,
+          <span class="italic-accent">research &amp; explainers</span>
+        </h1>
+        <p class="page-hero-description">VCASSE publishes practical research across Safety, Sustainability, and Ethics &mdash; written to inform Vancouver's policymakers, developers, and residents as AI reshapes public life.</p>
+      </div>
+      <aside class="publications-hero-visual" aria-hidden="true">
+        <div class="publications-hero-stat-card">
+          <div class="publications-hero-stat">
+            <span class="publications-hero-stat-num" id="publicationsHeroCount">6</span>
+            <span class="publications-hero-stat-label">publications</span>
+          </div>
+          <ul class="publications-hero-pillars">
+            <li><span class="publication-pill publication-pill--safety">Safety</span><span>2</span></li>
+            <li><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>2</span></li>
+            <li><span class="publication-pill publication-pill--ethics">Ethics</span><span>2</span></li>
+          </ul>
+          <p class="publications-hero-note">Updated continuously as our research program grows.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="publications-toolbar-section">
+    <div class="container">
+      <div class="publications-toolbar" role="region" aria-label="Publication filters">
+        <div class="publications-toolbar-row">
+          <div class="publication-filters" role="group" aria-label="Filter by pillar">
+            <button type="button" class="publication-filter active" data-pub-filter="all" aria-pressed="true">All</button>
+            <button type="button" class="publication-filter publication-filter--safety" data-pub-filter="safety" aria-pressed="false">Safety</button>
+            <button type="button" class="publication-filter publication-filter--sustainability" data-pub-filter="sustainability" aria-pressed="false">Sustainability</button>
+            <button type="button" class="publication-filter publication-filter--ethics" data-pub-filter="ethics" aria-pressed="false">Ethics</button>
+          </div>
+          <div class="publications-search">
+            <svg class="publications-search-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 2a8 8 0 1 0 5.3 14.06l4.33 4.33 1.42-1.42-4.33-4.33A8 8 0 0 0 10 2zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12z" fill="currentColor"/></svg>
+            <input type="search" id="publicationsSearch" placeholder="Search title, tag, or author" aria-label="Search publications">
+          </div>
+        </div>
+        <div class="publications-toolbar-row publications-toolbar-row--dense">
+          <div class="publications-select-group">
+            <label for="publicationsTag">Tag</label>
+            <select id="publicationsTag">
+              <option value="all">All tags</option>
+            </select>
+          </div>
+          <div class="publications-select-group">
+            <label for="publicationsSort">Sort</label>
+            <select id="publicationsSort">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="az">A &ndash; Z</option>
+            </select>
+          </div>
+          <p class="publications-count" id="publicationsCount" aria-live="polite">Showing all 6 publications</p>
+        </div>
       </div>
     </div>
   </section>
 
   <section class="home-section publications-index">
     <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Safety</p>
-        <h2 class="home-section-title">Safety publications</h2>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--safety">Safety</span>
-            <span>Mar 15, 2026</span>
-            <span>7 min read</span>
-          </div>
-          <h3>Practical AI Safety Evaluations for Public-Interest Teams</h3>
-          <p>A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
-          <ul class="publication-tags"><li>Evaluations</li><li>Risk</li><li>Governance</li></ul>
-          <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--safety">Safety</span>
-            <span>Dec 12, 2025</span>
-            <span>5 min read</span>
-          </div>
-          <h3>Incident Reporting Playbook for Responsible AI Teams</h3>
-          <p>A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p>
-          <ul class="publication-tags"><li>Operations</li><li>Incident Response</li><li>Monitoring</li></ul>
-          <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
+      <div class="publications-grid" id="publicationsGrid" aria-live="polite"></div>
+      <div class="publications-empty" id="publicationsEmpty" hidden>
+        <h3>No publications match those filters yet.</h3>
+        <p>Try a broader pillar, clear the search, or reset the filters.</p>
+        <button type="button" class="btn btn-secondary" id="publicationsReset">Reset filters</button>
       </div>
     </div>
   </section>
 
-  <section class="home-section publications-index">
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
     <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Sustainability</p>
-        <h2 class="home-section-title">Sustainability publications</h2>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--sustainability">Sustainability</span>
-            <span>Feb 27, 2026</span>
-            <span>6 min read</span>
-          </div>
-          <h3>A Sustainability Checklist for AI Procurement</h3>
-          <p>How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
-          <ul class="publication-tags"><li>Climate</li><li>Procurement</li><li>Infrastructure</li></ul>
-          <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--sustainability">Sustainability</span>
-            <span>Nov 19, 2025</span>
-            <span>6 min read</span>
-          </div>
-          <h3>Energy Footprint Reporting: A Starter Standard</h3>
-          <p>A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.</p>
-          <ul class="publication-tags"><li>Reporting</li><li>Standards</li><li>Metrics</li></ul>
-          <a class="modern-card-link" href="publications/energy-footprint-reporting-standard.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <section class="home-section publications-index">
-    <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Ethics</p>
-        <h2 class="home-section-title">Ethics publications</h2>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--ethics">Ethics</span>
-            <span>Jan 31, 2026</span>
-            <span>8 min read</span>
-          </div>
-          <h3>Participatory Ethics in Municipal AI Decisions</h3>
-          <p>Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
-          <ul class="publication-tags"><li>Inclusion</li><li>Policy</li><li>Public Deliberation</li></ul>
-          <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-        <article class="publication-card">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--ethics">Ethics</span>
-            <span>Oct 28, 2025</span>
-            <span>7 min read</span>
-          </div>
-          <h3>Human Oversight Design Patterns That Actually Work</h3>
-          <p>Common oversight patterns fail when reviewers are overloaded. These design patterns improve decision quality.</p>
-          <ul class="publication-tags"><li>Human-in-the-loop</li><li>UX</li><li>Accountability</li></ul>
-          <a class="modern-card-link" href="publications/human-oversight-design-patterns.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications, upcoming public panels, and plain-language notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();" aria-describedby="newsletter-soon-note">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note" id="newsletter-soon-note">Sign-ups open soon &mdash; we're still setting things up.</p>
+        </form>
       </div>
     </div>
   </section>
@@ -188,6 +172,8 @@
     </div>
   </footer>
 
+  <script src="js/publications-data.js"></script>
+  <script src="js/publications-page.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/dev/publications/energy-footprint-reporting-standard.html
+++ b/dev/publications/energy-footprint-reporting-standard.html
@@ -4,13 +4,173 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Energy Footprint Reporting: A Starter Standard | VCASSE</title>
+  <meta name="description" content="A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
 </head>
 <body>
-  <nav class="navbar"><div class="container"><a href="../index.html" class="nav-logo nav-logo-mark"><img src="../img/logo.svg" alt="VCASSE" width="28" height="28">VCASSE</a><ul class="nav-links" id="navLinks"><li><a href="../index.html"><span class="menu-label">Home</span></a></li><li class="nav-dropdown"><button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">Focus Areas<svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><ul class="nav-dropdown-menu" id="navResearchMenu" role="menu"><li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li><li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li><li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li></ul></li><li><a href="../events.html"><span class="menu-label">Events</span></a></li><li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li><li><a href="../about.html"><span class="menu-label">About</span></a></li><li><a href="../contact.html"><span class="menu-label">Contact</span></a></li></ul><button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu"><span></span><span></span><span></span></button></div></nav>
-  <section class="page-hero publication-hero"><div class="container"><div class="page-hero-content"><div class="section-label">PUBLICATION</div><h1 class="page-hero-title">Energy Footprint Reporting: A Starter Standard</h1><p class="page-hero-description">A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.</p><div class="publication-post-meta"><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>Nov 19, 2025</span><span>6 min read</span></div></div></div></section>
-  <section class="publication-body"><div class="container"><article class="publication-prose"><p>Energy reporting in AI remains inconsistent across institutions, making comparison and accountability difficult.</p><p>This starter standard recommends reporting by workload class, region, model family, and quarterly trend, with confidence notes where estimation is required.</p><p>Standardized disclosures can strengthen policy discussions and improve public trust without imposing excessive burden on smaller teams.</p></article><p><a href="../publications.html" class="modern-card-link">Back to all publications <span aria-hidden="true">→</span></a></p></div></section>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="publication-detail-hero">
+    <div class="container">
+      <p class="publication-detail-crumb"><a href="../publications.html">Publications</a> <span aria-hidden="true">/</span> <span>Sustainability</span></p>
+      <div class="publication-detail-grid">
+        <div class="publication-detail-text">
+          <span class="publication-pill publication-pill--sustainability">Sustainability</span>
+          <h1>Energy Footprint Reporting: A Starter Standard</h1>
+          <p class="publication-detail-lede">A baseline reporting format for teams that want to disclose AI energy impact with minimal overhead.</p>
+          <ul class="publication-detail-meta">
+            <li><span>Published</span><strong>Nov 19, 2025</strong></li>
+            <li><span>Reading</span><strong>6 min</strong></li>
+            <li><span>Authors</span><strong>Dr. Alejandro Ruiz</strong></li>
+          </ul>
+        </div>
+        <figure class="publication-detail-cover">
+          <img src="../img/publications/energy-footprint.svg" alt="Bar chart with overlay trend line representing energy reporting" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </section>
+
+  <section class="publication-body">
+    <div class="container publication-body-grid">
+      <article class="publication-prose">
+        <p>Energy reporting in AI is currently inconsistent. One team reports per-token energy, another reports per-request, a third reports nothing at all. Comparing across institutions is nearly impossible, which means accountability is too.</p>
+
+        <h2>Five fields, one quarterly cadence</h2>
+        <p>This starter standard recommends reporting five fields, every quarter:</p>
+        <ul>
+          <li><strong>Workload class</strong> &mdash; e.g. "chat assistant", "document classification", "image generation".</li>
+          <li><strong>Region</strong> &mdash; the data centre region where most inference occurred.</li>
+          <li><strong>Model family</strong> &mdash; the family or generation, not the exact checkpoint.</li>
+          <li><strong>Energy estimate</strong> &mdash; kWh per million requests, with a confidence band.</li>
+          <li><strong>Method</strong> &mdash; measured, modelled, or vendor-supplied.</li>
+        </ul>
+        <p>That's it. Five fields. Quarterly. The simplicity is the point: a standard that is too heavy will be ignored, and a standard that is ignored disclosing nothing.</p>
+
+        <h2>Confidence bands matter</h2>
+        <p>Estimation in AI energy reporting is unavoidable. We strongly recommend publishing a confidence band rather than a single number. A range of "120 &ndash; 180 kWh/Mreq, modelled" is more honest, and more useful, than a precise-looking but unsupported figure.</p>
+
+        <h2>How this fits with broader climate disclosure</h2>
+        <p>The starter standard is designed to nest inside existing climate disclosure frameworks (GHG Protocol, ISO 14064, CDP). It does not replace them &mdash; it gives small teams a way to start producing comparable AI-specific numbers immediately, while larger teams build out full Scope 2 and Scope 3 accounting.</p>
+      </article>
+
+      <aside class="publication-aside" aria-label="Publication summary">
+        <div class="publication-aside-card">
+          <h3>The five fields</h3>
+          <ul>
+            <li>Workload class.</li>
+            <li>Region.</li>
+            <li>Model family.</li>
+            <li>kWh per million requests, with confidence band.</li>
+            <li>Method &mdash; measured, modelled, or vendor-supplied.</li>
+          </ul>
+        </div>
+        <div class="publication-aside-card publication-aside-card--tags">
+          <h3>Tagged</h3>
+          <ul class="publication-tags">
+            <li>Reporting</li><li>Standards</li><li>Metrics</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="home-section publications-related">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Related</p>
+        <h2 class="home-section-title">More from Sustainability</h2>
+      </header>
+      <div class="publication-cards-grid" data-related-publications data-pillar="sustainability" data-limit="2" data-exclude="energy-footprint-reporting-standard"></div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications and notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note">Sign-ups open soon.</p>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-related.js"></script>
   <script src="../js/main.js"></script>
 </body>
 </html>

--- a/dev/publications/human-oversight-design-patterns.html
+++ b/dev/publications/human-oversight-design-patterns.html
@@ -4,13 +4,176 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Human Oversight Design Patterns That Actually Work | VCASSE</title>
+  <meta name="description" content="Design patterns that improve decision quality when humans are asked to review AI outputs.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
 </head>
 <body>
-  <nav class="navbar"><div class="container"><a href="../index.html" class="nav-logo nav-logo-mark"><img src="../img/logo.svg" alt="VCASSE" width="28" height="28">VCASSE</a><ul class="nav-links" id="navLinks"><li><a href="../index.html"><span class="menu-label">Home</span></a></li><li class="nav-dropdown"><button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">Focus Areas<svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><ul class="nav-dropdown-menu" id="navResearchMenu" role="menu"><li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li><li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li><li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li></ul></li><li><a href="../events.html"><span class="menu-label">Events</span></a></li><li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li><li><a href="../about.html"><span class="menu-label">About</span></a></li><li><a href="../contact.html"><span class="menu-label">Contact</span></a></li></ul><button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu"><span></span><span></span><span></span></button></div></nav>
-  <section class="page-hero publication-hero"><div class="container"><div class="page-hero-content"><div class="section-label">PUBLICATION</div><h1 class="page-hero-title">Human Oversight Design Patterns That Actually Work</h1><p class="page-hero-description">Common oversight patterns fail when reviewers are overloaded. These design patterns improve decision quality.</p><div class="publication-post-meta"><span class="publication-pill publication-pill--ethics">Ethics</span><span>Oct 28, 2025</span><span>7 min read</span></div></div></div></section>
-  <section class="publication-body"><div class="container"><article class="publication-prose"><p>Human-in-the-loop can become a checkbox if review systems are poorly designed. Effective oversight requires clear context, confidence cues, and escalation pathways.</p><p>This publication outlines practical UX and process patterns that reduce reviewer fatigue and increase accountability in high-impact decision settings.</p><p>Organizations should treat oversight quality as a design responsibility, not only a policy statement.</p></article><p><a href="../publications.html" class="modern-card-link">Back to all publications <span aria-hidden="true">→</span></a></p></div></section>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="publication-detail-hero">
+    <div class="container">
+      <p class="publication-detail-crumb"><a href="../publications.html">Publications</a> <span aria-hidden="true">/</span> <span>Ethics</span></p>
+      <div class="publication-detail-grid">
+        <div class="publication-detail-text">
+          <span class="publication-pill publication-pill--ethics">Ethics</span>
+          <h1>Human Oversight Design Patterns That Actually Work</h1>
+          <p class="publication-detail-lede">Common oversight patterns fail when reviewers are overloaded. These design patterns improve decision quality.</p>
+          <ul class="publication-detail-meta">
+            <li><span>Published</span><strong>Oct 28, 2025</strong></li>
+            <li><span>Reading</span><strong>7 min</strong></li>
+            <li><span>Authors</span><strong>Dr. Amara Okafor</strong></li>
+          </ul>
+        </div>
+        <figure class="publication-detail-cover">
+          <img src="../img/publications/human-oversight.svg" alt="Stylised eye and review trail representing human oversight" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </section>
+
+  <section class="publication-body">
+    <div class="container publication-body-grid">
+      <article class="publication-prose">
+        <p>Human-in-the-loop becomes a checkbox the moment review systems are poorly designed. A reviewer asked to approve 200 model outputs an hour is not providing oversight &mdash; they are providing a rubber stamp at scale. The fix is not "try harder"; it's a different design.</p>
+
+        <h2>Patterns that work</h2>
+        <ul>
+          <li><strong>Confidence-tiered review.</strong> Send only borderline outputs for human review; auto-approve the obvious ones and auto-reject the obvious failures, with clear thresholds documented.</li>
+          <li><strong>Two-pane context.</strong> Show the input alongside the output, plus a third pane with the relevant policy and prior similar decisions.</li>
+          <li><strong>Explicit "I don't know" affordance.</strong> Reviewers must be able to escalate without penalty. Designs that punish "unsure" produce false confidence.</li>
+          <li><strong>Decision logs that read back.</strong> Each decision links to the criteria that made it, so the same reviewer (or a different one) can revisit it later.</li>
+        </ul>
+
+        <h2>Anti-patterns to avoid</h2>
+        <ul>
+          <li>One-click approve with no friction differential between high- and low-stakes outputs.</li>
+          <li>Quotas that incentivise speed over quality.</li>
+          <li>UI that hides the model's confidence score from the reviewer.</li>
+          <li>Review queues with no escalation path.</li>
+        </ul>
+
+        <h2>Oversight is a design responsibility</h2>
+        <p>The single biggest move teams can make is to stop treating oversight as a policy line ("a human will review") and start treating it as a UX problem. The reviewer's environment, workload, training, and tools determine whether oversight is real or theatrical.</p>
+
+        <blockquote class="publication-pull">"If your reviewer can't say 'I don't know' without penalty, you are not running oversight. You are running approval."</blockquote>
+      </article>
+
+      <aside class="publication-aside" aria-label="Publication summary">
+        <div class="publication-aside-card">
+          <h3>Patterns to adopt</h3>
+          <ul>
+            <li>Confidence-tiered review.</li>
+            <li>Two-pane context with policy and precedent.</li>
+            <li>Explicit "I don't know" affordance.</li>
+            <li>Decision logs that link back to criteria.</li>
+          </ul>
+        </div>
+        <div class="publication-aside-card publication-aside-card--tags">
+          <h3>Tagged</h3>
+          <ul class="publication-tags">
+            <li>Human-in-the-loop</li><li>UX</li><li>Accountability</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="home-section publications-related">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Related</p>
+        <h2 class="home-section-title">More from Ethics</h2>
+      </header>
+      <div class="publication-cards-grid" data-related-publications data-pillar="ethics" data-limit="2" data-exclude="human-oversight-design-patterns"></div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications and notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note">Sign-ups open soon.</p>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-related.js"></script>
   <script src="../js/main.js"></script>
 </body>
 </html>

--- a/dev/publications/incident-reporting-playbook.html
+++ b/dev/publications/incident-reporting-playbook.html
@@ -4,13 +4,171 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Incident Reporting Playbook for Responsible AI Teams | VCASSE</title>
+  <meta name="description" content="A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
 </head>
 <body>
-  <nav class="navbar"><div class="container"><a href="../index.html" class="nav-logo nav-logo-mark"><img src="../img/logo.svg" alt="VCASSE" width="28" height="28">VCASSE</a><ul class="nav-links" id="navLinks"><li><a href="../index.html"><span class="menu-label">Home</span></a></li><li class="nav-dropdown"><button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">Focus Areas<svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><ul class="nav-dropdown-menu" id="navResearchMenu" role="menu"><li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li><li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li><li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li></ul></li><li><a href="../events.html"><span class="menu-label">Events</span></a></li><li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li><li><a href="../about.html"><span class="menu-label">About</span></a></li><li><a href="../contact.html"><span class="menu-label">Contact</span></a></li></ul><button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu"><span></span><span></span><span></span></button></div></nav>
-  <section class="page-hero publication-hero"><div class="container"><div class="page-hero-content"><div class="section-label">PUBLICATION</div><h1 class="page-hero-title">Incident Reporting Playbook for Responsible AI Teams</h1><p class="page-hero-description">A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p><div class="publication-post-meta"><span class="publication-pill publication-pill--safety">Safety</span><span>Dec 12, 2025</span><span>5 min read</span></div></div></div></section>
-  <section class="publication-body"><div class="container"><article class="publication-prose"><p>Teams often detect AI failures but lack a shared response protocol. This playbook introduces severity tiers, ownership assignments, escalation windows, and post-incident documentation standards.</p><p>VCASSE proposes consistent incident taxonomies so safety events can be tracked across tools, vendors, and departments. Clear categorization helps organizations move from reaction to prevention.</p><p>Postmortems should include model behavior, social impact, mitigation timing, and corrective actions for future deployments.</p></article><p><a href="../publications.html" class="modern-card-link">Back to all publications <span aria-hidden="true">→</span></a></p></div></section>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="publication-detail-hero">
+    <div class="container">
+      <p class="publication-detail-crumb"><a href="../publications.html">Publications</a> <span aria-hidden="true">/</span> <span>Safety</span></p>
+      <div class="publication-detail-grid">
+        <div class="publication-detail-text">
+          <span class="publication-pill publication-pill--safety">Safety</span>
+          <h1>Incident Reporting Playbook for Responsible AI Teams</h1>
+          <p class="publication-detail-lede">A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p>
+          <ul class="publication-detail-meta">
+            <li><span>Published</span><strong>Dec 12, 2025</strong></li>
+            <li><span>Reading</span><strong>5 min</strong></li>
+            <li><span>Authors</span><strong>Priya Sandhu</strong></li>
+          </ul>
+        </div>
+        <figure class="publication-detail-cover">
+          <img src="../img/publications/incident-reporting.svg" alt="Signal waveform illustrating incident detection and escalation" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </section>
+
+  <section class="publication-body">
+    <div class="container publication-body-grid">
+      <article class="publication-prose">
+        <p>Most AI-related incidents are detected by someone who isn't on the team that built the model. The bottleneck is rarely detection &mdash; it's escalation. Without a shared protocol, hours pass between a problem being noticed and the right people hearing about it.</p>
+
+        <h2>Three layers of severity</h2>
+        <p>This playbook proposes three response tiers:</p>
+        <ul>
+          <li><strong>Tier 1 &mdash; observable issue</strong>: model output looks wrong, but no one is harmed yet. Document, monitor, schedule fix.</li>
+          <li><strong>Tier 2 &mdash; user impact</strong>: a person receives a wrong, biased, or harmful output. Page the on-call owner; mitigate within hours.</li>
+          <li><strong>Tier 3 &mdash; systemic harm</strong>: the issue affects a protected group, a regulated process, or public safety. Page leadership; consider taking the system offline.</li>
+        </ul>
+
+        <h2>Ownership and escalation windows</h2>
+        <p>Each tier has a named owner and a time-boxed escalation window. The owner is accountable for both the technical fix and the public-facing communication. We recommend that public-sector teams publish their on-call rota internally so non-engineers know who to reach when something goes wrong.</p>
+
+        <h2>Postmortems that change behaviour</h2>
+        <p>A postmortem is only valuable if it changes the next deployment. VCASSE recommends documenting four things every time: what happened, who was affected, what we will change in the system, and what we will change in our process. The fourth is the one most teams skip &mdash; and it's the one that compounds.</p>
+
+        <blockquote class="publication-pull">"The point of a playbook is not to predict every failure. It's to make sure that when one happens, the response is boring."</blockquote>
+      </article>
+
+      <aside class="publication-aside" aria-label="Publication summary">
+        <div class="publication-aside-card">
+          <h3>Key takeaways</h3>
+          <ul>
+            <li>Adopt three explicit severity tiers with named owners.</li>
+            <li>Set escalation windows in hours, not "as soon as possible".</li>
+            <li>Page leadership when harm crosses into protected groups or regulated processes.</li>
+            <li>Postmortems must change the next deployment, not just the team's notes.</li>
+          </ul>
+        </div>
+        <div class="publication-aside-card publication-aside-card--tags">
+          <h3>Tagged</h3>
+          <ul class="publication-tags">
+            <li>Operations</li><li>Incident Response</li><li>Monitoring</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="home-section publications-related">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Related</p>
+        <h2 class="home-section-title">More from Safety</h2>
+      </header>
+      <div class="publication-cards-grid" data-related-publications data-pillar="safety" data-limit="2" data-exclude="incident-reporting-playbook"></div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications and notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note">Sign-ups open soon.</p>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-related.js"></script>
   <script src="../js/main.js"></script>
 </body>
 </html>

--- a/dev/publications/participatory-ethics-municipal-ai.html
+++ b/dev/publications/participatory-ethics-municipal-ai.html
@@ -4,13 +4,170 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Participatory Ethics in Municipal AI Decisions | VCASSE</title>
+  <meta name="description" content="Why public-facing AI decisions should include structured resident participation, not only internal review.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
 </head>
 <body>
-  <nav class="navbar"><div class="container"><a href="../index.html" class="nav-logo nav-logo-mark"><img src="../img/logo.svg" alt="VCASSE" width="28" height="28">VCASSE</a><ul class="nav-links" id="navLinks"><li><a href="../index.html"><span class="menu-label">Home</span></a></li><li class="nav-dropdown"><button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">Focus Areas<svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><ul class="nav-dropdown-menu" id="navResearchMenu" role="menu"><li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li><li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li><li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li></ul></li><li><a href="../events.html"><span class="menu-label">Events</span></a></li><li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li><li><a href="../about.html"><span class="menu-label">About</span></a></li><li><a href="../contact.html"><span class="menu-label">Contact</span></a></li></ul><button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu"><span></span><span></span><span></span></button></div></nav>
-  <section class="page-hero publication-hero"><div class="container"><div class="page-hero-content"><div class="section-label">PUBLICATION</div><h1 class="page-hero-title">Participatory Ethics in Municipal AI Decisions</h1><p class="page-hero-description">Why public-facing AI decisions should include structured resident participation, not only internal review.</p><div class="publication-post-meta"><span class="publication-pill publication-pill--ethics">Ethics</span><span>Jan 31, 2026</span><span>8 min read</span></div></div></div></section>
-  <section class="publication-body"><div class="container"><article class="publication-prose"><p>Ethics reviews are strongest when affected communities can shape criteria and outcomes, not only react after deployment.</p><p>VCASSE recommends publishing use-case briefs, running targeted listening sessions, and documenting how resident feedback changes deployment decisions.</p><p>This participatory model strengthens legitimacy, surfaces lived-experience risk, and supports more accountable public-sector AI governance.</p></article><p><a href="../publications.html" class="modern-card-link">Back to all publications <span aria-hidden="true">→</span></a></p></div></section>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="publication-detail-hero">
+    <div class="container">
+      <p class="publication-detail-crumb"><a href="../publications.html">Publications</a> <span aria-hidden="true">/</span> <span>Ethics</span></p>
+      <div class="publication-detail-grid">
+        <div class="publication-detail-text">
+          <span class="publication-pill publication-pill--ethics">Ethics</span>
+          <h1>Participatory Ethics in Municipal AI Decisions</h1>
+          <p class="publication-detail-lede">Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
+          <ul class="publication-detail-meta">
+            <li><span>Published</span><strong>Jan 31, 2026</strong></li>
+            <li><span>Reading</span><strong>8 min</strong></li>
+            <li><span>Authors</span><strong>Dr. Amara Okafor, Jordan Blackwood</strong></li>
+          </ul>
+        </div>
+        <figure class="publication-detail-cover">
+          <img src="../img/publications/participatory-ethics.svg" alt="Connected nodes representing residents linked into a decision network" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </section>
+
+  <section class="publication-body">
+    <div class="container publication-body-grid">
+      <article class="publication-prose">
+        <p>Ethics reviews are strongest when affected communities can shape the criteria and the outcome &mdash; not when they are asked to react to a decision that has already been made. Most municipal AI projects today still treat residents as the audience for a final answer, rather than as participants in defining the question.</p>
+
+        <h2>Three concrete practices</h2>
+        <ol>
+          <li><strong>Publish a use-case brief before procurement.</strong> A two-page plain-language document describing the problem, the proposed system, and the populations most affected.</li>
+          <li><strong>Run targeted listening sessions.</strong> Invite the populations most likely to encounter the system &mdash; not only the public-at-large &mdash; and document what changes as a result.</li>
+          <li><strong>Maintain a deliberation trail.</strong> Make it easy for residents to see what feedback was received and how it influenced the deployment, including where it was overruled and why.</li>
+        </ol>
+
+        <h2>Participation is not the same as polling</h2>
+        <p>A survey can tell you what a population thinks about a system in the abstract. Participation tells you what changes when people sit with the actual decision: which language coverage matters, which appeals process works, which communications are trusted. These are findings that don't show up in a Likert scale.</p>
+
+        <h2>What this looks like in Vancouver</h2>
+        <p>VCASSE is piloting this approach with two municipal partners in 2026. Early findings: structured listening surfaced accessibility considerations that internal review had missed entirely, and changed the eligibility logic of one decision-support tool before it shipped.</p>
+
+        <blockquote class="publication-pull">"Residents are not the audience for a public-sector AI decision. They are co-authors of it."</blockquote>
+      </article>
+
+      <aside class="publication-aside" aria-label="Publication summary">
+        <div class="publication-aside-card">
+          <h3>Practices to adopt</h3>
+          <ul>
+            <li>Publish a plain-language use-case brief before procurement.</li>
+            <li>Run targeted listening sessions with affected populations.</li>
+            <li>Maintain a public deliberation trail showing how feedback shaped decisions.</li>
+            <li>Treat residents as co-authors, not respondents.</li>
+          </ul>
+        </div>
+        <div class="publication-aside-card publication-aside-card--tags">
+          <h3>Tagged</h3>
+          <ul class="publication-tags">
+            <li>Inclusion</li><li>Policy</li><li>Public Deliberation</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="home-section publications-related">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Related</p>
+        <h2 class="home-section-title">More from Ethics</h2>
+      </header>
+      <div class="publication-cards-grid" data-related-publications data-pillar="ethics" data-limit="2" data-exclude="participatory-ethics-municipal-ai"></div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications and notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note">Sign-ups open soon.</p>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-related.js"></script>
   <script src="../js/main.js"></script>
 </body>
 </html>

--- a/dev/publications/safety-evaluations-public-interest.html
+++ b/dev/publications/safety-evaluations-public-interest.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Practical AI Safety Evaluations for Public-Interest Teams | VCASSE</title>
+  <meta name="description" content="A practical framework for evaluating AI failure modes before deployment in civic and public-service contexts.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
 </head>
@@ -38,32 +39,140 @@
     </div>
   </nav>
 
-  <section class="page-hero publication-hero">
+  <section class="publication-detail-hero">
     <div class="container">
-      <div class="page-hero-content">
-        <div class="section-label">PUBLICATION</div>
-        <h1 class="page-hero-title">Practical AI Safety Evaluations for Public-Interest Teams</h1>
-        <p class="page-hero-description">A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
-        <div class="publication-post-meta">
+      <p class="publication-detail-crumb"><a href="../publications.html">Publications</a> <span aria-hidden="true">/</span> <span>Safety</span></p>
+      <div class="publication-detail-grid">
+        <div class="publication-detail-text">
           <span class="publication-pill publication-pill--safety">Safety</span>
-          <span>Mar 15, 2026</span>
-          <span>7 min read</span>
+          <h1>Practical AI Safety Evaluations for Public-Interest Teams</h1>
+          <p class="publication-detail-lede">A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
+          <ul class="publication-detail-meta">
+            <li><span>Published</span><strong>Mar 15, 2026</strong></li>
+            <li><span>Reading</span><strong>7 min</strong></li>
+            <li><span>Authors</span><strong>Dr. Mei Tanaka, Priya Sandhu</strong></li>
+          </ul>
         </div>
+        <figure class="publication-detail-cover">
+          <img src="../img/publications/safety-evaluations.svg" alt="Concentric ring illustration representing layered AI evaluation rounds" loading="lazy">
+        </figure>
       </div>
     </div>
   </section>
 
   <section class="publication-body">
-    <div class="container">
+    <div class="container publication-body-grid">
       <article class="publication-prose">
-        <p>AI evaluations should be understandable, repeatable, and proportionate to risk. For most public-interest teams, the challenge is not whether to evaluate systems, but how to do it with limited staff and budget.</p>
-        <p>VCASSE recommends a lightweight evaluation loop: define high-impact failure classes, design representative test sets, review findings with non-technical stakeholders, and publish plain-language summaries.</p>
-        <p>This approach improves transparency while giving policymakers and residents a clearer view of system behavior before deployment at scale.</p>
+        <p>AI evaluations should be understandable, repeatable, and proportionate to risk. For most public-interest teams, the challenge is not whether to evaluate systems, but how to do it with limited staff and budget &mdash; and how to communicate the result so that residents, elected officials, and journalists can engage with it.</p>
+
+        <h2>The lightweight evaluation loop</h2>
+        <p>VCASSE recommends a four-step loop you can run on a single sprint:</p>
+        <ol>
+          <li><strong>Define high-impact failure classes</strong> with the team that will be accountable for the system in production.</li>
+          <li><strong>Design representative test sets</strong> that reflect Vancouver's languages, neighbourhoods, accessibility needs, and edge cases.</li>
+          <li><strong>Review findings with non-technical stakeholders</strong> &mdash; service designers, frontline staff, and at least one external civic partner.</li>
+          <li><strong>Publish plain-language summaries</strong> that pair each metric with a short, honest interpretation.</li>
+        </ol>
+
+        <h2>What to test for first</h2>
+        <p>Public-interest deployments tend to fail along a small set of recurring axes: language coverage, demographic skew, refusal under stress, and brittle behaviour around novel jurisdictional inputs. Starting evaluations there closes the most common gaps before the system reaches a real applicant.</p>
+
+        <h2>Why the public summary matters</h2>
+        <p>A test report that no one outside the engineering team reads cannot create accountability. Plain-language summaries give policymakers and residents a shared reference, and they make it possible to compare deployments across departments and vendors.</p>
+
+        <blockquote class="publication-pull">"If you can't describe a failure mode in two sentences a city councillor would understand, you haven't tested for it yet."</blockquote>
+
+        <h2>Where to go from here</h2>
+        <p>This brief is the first in a series. Upcoming notes will cover red-teaming for civic chatbots, evaluation cadence after deployment, and how to share evaluation infrastructure across municipalities.</p>
       </article>
-      <p><a href="../publications.html" class="modern-card-link">Back to all publications <span aria-hidden="true">→</span></a></p>
+
+      <aside class="publication-aside" aria-label="Publication summary">
+        <div class="publication-aside-card">
+          <h3>Key takeaways</h3>
+          <ul>
+            <li>Run a four-step evaluation loop sized for small public teams.</li>
+            <li>Test first for language coverage, demographic skew, refusal, and novel input behaviour.</li>
+            <li>Publish plain-language summaries alongside any metric.</li>
+            <li>Treat evaluation reports as governance artefacts, not engineering memos.</li>
+          </ul>
+        </div>
+        <div class="publication-aside-card publication-aside-card--tags">
+          <h3>Tagged</h3>
+          <ul class="publication-tags">
+            <li>Evaluations</li><li>Risk</li><li>Governance</li>
+          </ul>
+        </div>
+      </aside>
     </div>
   </section>
 
+  <section class="home-section publications-related">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Related</p>
+        <h2 class="home-section-title">More from Safety</h2>
+      </header>
+      <div class="publication-cards-grid" data-related-publications data-pillar="safety" data-limit="2" data-exclude="safety-evaluations-public-interest"></div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications and notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note">Sign-ups open soon.</p>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-related.js"></script>
   <script src="../js/main.js"></script>
 </body>
 </html>

--- a/dev/publications/sustainability-procurement-checklist.html
+++ b/dev/publications/sustainability-procurement-checklist.html
@@ -4,13 +4,171 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>A Sustainability Checklist for AI Procurement | VCASSE</title>
+  <meta name="description" content="How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
 </head>
 <body>
-  <nav class="navbar"><div class="container"><a href="../index.html" class="nav-logo nav-logo-mark"><img src="../img/logo.svg" alt="VCASSE" width="28" height="28">VCASSE</a><ul class="nav-links" id="navLinks"><li><a href="../index.html"><span class="menu-label">Home</span></a></li><li class="nav-dropdown"><button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">Focus Areas<svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button><ul class="nav-dropdown-menu" id="navResearchMenu" role="menu"><li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li><li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li><li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li></ul></li><li><a href="../events.html"><span class="menu-label">Events</span></a></li><li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li><li><a href="../about.html"><span class="menu-label">About</span></a></li><li><a href="../contact.html"><span class="menu-label">Contact</span></a></li></ul><button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu"><span></span><span></span><span></span></button></div></nav>
-  <section class="page-hero publication-hero"><div class="container"><div class="page-hero-content"><div class="section-label">PUBLICATION</div><h1 class="page-hero-title">A Sustainability Checklist for AI Procurement</h1><p class="page-hero-description">How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p><div class="publication-post-meta"><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>Feb 27, 2026</span><span>6 min read</span></div></div></div></section>
-  <section class="publication-body"><div class="container"><article class="publication-prose"><p>Many organizations buy AI capabilities without visibility into compute intensity, infrastructure sourcing, or lifecycle environmental costs.</p><p>This checklist introduces practical procurement prompts: request workload energy ranges, ask for location-specific water intensity data, and include environmental disclosures in contracts.</p><p>Better procurement questions drive better market behavior and help Vancouver institutions align AI adoption with sustainability commitments.</p></article><p><a href="../publications.html" class="modern-card-link">Back to all publications <span aria-hidden="true">→</span></a></p></div></section>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="publication-detail-hero">
+    <div class="container">
+      <p class="publication-detail-crumb"><a href="../publications.html">Publications</a> <span aria-hidden="true">/</span> <span>Sustainability</span></p>
+      <div class="publication-detail-grid">
+        <div class="publication-detail-text">
+          <span class="publication-pill publication-pill--sustainability">Sustainability</span>
+          <h1>A Sustainability Checklist for AI Procurement</h1>
+          <p class="publication-detail-lede">How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
+          <ul class="publication-detail-meta">
+            <li><span>Published</span><strong>Feb 27, 2026</strong></li>
+            <li><span>Reading</span><strong>6 min</strong></li>
+            <li><span>Authors</span><strong>Dr. Alejandro Ruiz, Linh Nguyen</strong></li>
+          </ul>
+        </div>
+        <figure class="publication-detail-cover">
+          <img src="../img/publications/sustainability-procurement.svg" alt="Stacked checklist tiles representing procurement criteria" loading="lazy">
+        </figure>
+      </div>
+    </div>
+  </section>
+
+  <section class="publication-body">
+    <div class="container publication-body-grid">
+      <article class="publication-prose">
+        <p>Many organizations buy AI capabilities without visibility into compute intensity, infrastructure sourcing, or lifecycle environmental costs. The contract is signed, the API key is provisioned, and only later does someone ask whether the energy footprint matches the institution's climate commitments.</p>
+
+        <h2>Four questions every contract should answer</h2>
+        <ol>
+          <li><strong>Workload energy ranges.</strong> What is a typical kWh-per-1000-requests for the workload class we will use?</li>
+          <li><strong>Region and grid mix.</strong> Where will inference run, and what is the grid intensity at that location during our hours?</li>
+          <li><strong>Water and cooling.</strong> Is potable water used for cooling? What is the water usage effectiveness for the relevant facility?</li>
+          <li><strong>Lifecycle and end-of-life.</strong> How is hardware retired, and is e-waste handled by a certified processor?</li>
+        </ol>
+
+        <h2>Make sustainability a contract clause, not a hope</h2>
+        <p>Verbal commitments don't survive procurement renewals. We recommend a short standardized clause that requires annual environmental disclosures and gives the buyer the right to publish them. If a vendor cannot answer the four questions above, that is a finding worth recording before signing.</p>
+
+        <h2>Procurement is climate policy</h2>
+        <p>Cities and public institutions buy enormous quantities of AI capacity. The questions they ask shape the market more than any non-binding pledge. Vancouver-area institutions are well-positioned to lead by treating procurement as the climate lever it is.</p>
+
+        <blockquote class="publication-pull">"You don't need a perfect emissions number. You need a number you can compare next year."</blockquote>
+      </article>
+
+      <aside class="publication-aside" aria-label="Publication summary">
+        <div class="publication-aside-card">
+          <h3>The four-question checklist</h3>
+          <ul>
+            <li>Workload energy ranges per 1k requests.</li>
+            <li>Inference region and grid mix.</li>
+            <li>Water and cooling intensity.</li>
+            <li>Hardware lifecycle and e-waste handling.</li>
+          </ul>
+        </div>
+        <div class="publication-aside-card publication-aside-card--tags">
+          <h3>Tagged</h3>
+          <ul class="publication-tags">
+            <li>Climate</li><li>Procurement</li><li>Infrastructure</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="home-section publications-related">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Related</p>
+        <h2 class="home-section-title">More from Sustainability</h2>
+      </header>
+      <div class="publication-cards-grid" data-related-publications data-pillar="sustainability" data-limit="2" data-exclude="sustainability-procurement-checklist"></div>
+    </div>
+  </section>
+
+  <section class="newsletter-band" aria-labelledby="newsletter-heading">
+    <div class="container">
+      <div class="newsletter-card">
+        <div class="newsletter-content">
+          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+          <p class="newsletter-lede">A monthly dispatch with new publications and notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+        </div>
+        <form class="newsletter-form" onsubmit="event.preventDefault();">
+          <label for="newsletter-email" class="visually-hidden">Email address</label>
+          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
+          <p class="newsletter-note">Sign-ups open soon.</p>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-related.js"></script>
   <script src="../js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Publications index now has a hero stat card, pillar/tag/sort/search
filter toolbar, dynamic card grid with cover images, an empty-state,
and a newsletter "coming soon" block. Each card and detail page uses a
themed SVG cover, and detail pages have richer prose, a key-takeaways
aside, and a related-publications section.

Contact page adds quick-link chips, expanded contact channels (general,
media, research), an office-hours card, a 5-question FAQ, and the same
newsletter block. All new layouts are responsive and stay within the
existing dark-blue palette.