### PR TITLE
Simplify and refine newsletter section to match site style

### DIFF
--- a/dev/contact.html
+++ b/dev/contact.html
@@ -198,17 +198,15 @@
   <section class="newsletter-band" aria-labelledby="newsletter-heading">
     <div class="container">
       <div class="newsletter-card">
-        <div class="newsletter-content">
-          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
-          <h2 id="newsletter-heading">The VCASSE Briefing</h2>
-          <p class="newsletter-lede">A monthly dispatch with new publications, upcoming public panels, and plain-language notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
-        </div>
+        <p class="newsletter-kicker"><span class="newsletter-soon">Coming soon</span></p>
+        <h2 id="newsletter-heading">The VCASSE Briefing</h2>
+        <p class="newsletter-lede">Monthly notes on AI policy, infrastructure, and ethics for Vancouver.</p>
         <form class="newsletter-form" onsubmit="event.preventDefault();" aria-describedby="newsletter-soon-note">
           <label for="newsletter-email" class="visually-hidden">Email address</label>
-          <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
-          <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
-          <p class="newsletter-note" id="newsletter-soon-note">Sign-ups open soon &mdash; we're still setting things up.</p>
+          <input type="email" id="newsletter-email" placeholder="your@email.com" disabled aria-disabled="true">
+          <button type="button" class="btn btn-white" disabled aria-disabled="true">Notify me</button>
         </form>
+        <p class="newsletter-note" id="newsletter-soon-note">Sign-ups opening soon.</p>
       </div>
     </div>
   </section>

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -2678,15 +2678,15 @@ noscript + * .fade-in,
 .newsletter-card {
   background: linear-gradient(160deg, var(--bg-dark) 0%, var(--primary-dark) 60%, var(--primary) 130%);
   color: var(--white);
-  border-radius: 22px;
-  padding: 48px;
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-  gap: 40px;
+  border-radius: 20px;
+  padding: 60px 48px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  text-align: center;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 30px 60px -32px rgba(8, 42, 77, 0.55);
+  box-shadow: 0 20px 48px -16px rgba(8, 42, 77, 0.45);
 }
 
 .newsletter-card::before {
@@ -2704,26 +2704,22 @@ noscript + * .fade-in,
 }
 
 .newsletter-kicker {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(207, 226, 243, 0.75);
-  margin-bottom: 12px;
+  margin-bottom: 16px;
 }
 
 .newsletter-soon {
   display: inline-block;
-  padding: 3px 8px;
+  padding: 4px 12px;
   border: 1px solid var(--green-accent);
   color: var(--green-accent);
   border-radius: 999px;
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.14em;
-  margin-left: 4px;
+  text-transform: uppercase;
 }
 
-.newsletter-content h2 {
+.newsletter-card h2 {
   font-family: var(--font-display);
   font-weight: 700;
   font-size: clamp(1.75rem, 3vw, 2.4rem);
@@ -2737,22 +2733,24 @@ noscript + * .fade-in,
   font-size: 15px;
   line-height: 1.7;
   color: rgba(226, 232, 240, 0.78);
-  margin: 0;
+  margin: 0 0 28px;
+  max-width: 460px;
 }
 
 .newsletter-form {
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
   gap: 10px;
-  align-items: center;
+  width: 100%;
+  max-width: 420px;
+  margin-bottom: 14px;
 }
 
 .newsletter-form input {
-  grid-column: 1 / 2;
-  padding: 14px 18px;
-  border-radius: 999px;
+  flex: 1;
+  padding: 13px 18px;
+  border-radius: var(--radius-md);
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.1);
   color: var(--white);
   font-family: var(--font-sans);
   font-size: 14px;
@@ -2765,11 +2763,10 @@ noscript + * .fade-in,
 }
 
 .newsletter-form .btn {
-  grid-column: 2 / 3;
-  padding: 14px 24px;
-  border-radius: 999px;
+  padding: 13px 22px;
+  border-radius: var(--radius-md);
   cursor: not-allowed;
-  opacity: 0.65;
+  opacity: 0.8;
 }
 
 .newsletter-form .btn:disabled,
@@ -2778,11 +2775,10 @@ noscript + * .fade-in,
 }
 
 .newsletter-note {
-  grid-column: 1 / -1;
-  margin: 4px 0 0;
   font-size: 12px;
   letter-spacing: 0.04em;
-  color: rgba(207, 226, 243, 0.65);
+  color: rgba(207, 226, 243, 0.55);
+  margin: 0;
 }
 
 /* ─────────────── CONTACT PAGE EXTRAS ─────────────── */
@@ -2981,8 +2977,7 @@ noscript + * .fade-in,
     justify-content: flex-start;
   }
   .newsletter-card {
-    grid-template-columns: 1fr;
-    padding: 36px;
+    padding: 40px 36px;
   }
 }
 
@@ -3022,14 +3017,12 @@ noscript + * .fade-in,
     padding: 56px 0 40px;
   }
   .newsletter-card {
-    padding: 28px;
-    border-radius: 18px;
+    padding: 36px 24px;
+    border-radius: 16px;
   }
   .newsletter-form {
-    grid-template-columns: 1fr;
-  }
-  .newsletter-form .btn {
-    grid-column: 1 / -1;
+    flex-direction: column;
+    max-width: 100%;
   }
   .contact-faq {
     padding: 56px 0;


### PR DESCRIPTION
Redesigned newsletter section from two-column grid to centered flex
layout. Removed em dash from note text. Simplified kicker to badge
only, shortened lede, switched to btn-white for the dark background,
and updated responsive rules to match the new flex-based layout.

https://claude.ai/code/session_018m4c7itKZwTU1CwpDqKyk5