### PR TITLE
Redesign index page hero and fix mobile typography

### DIFF
--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -410,14 +410,14 @@ img { max-width: 100%; height: auto; display: block; }
 .hero-title {
   font-family: var(--font-sans);
   font-weight: 800;
-  font-size: clamp(2.25rem, 5vw + 1.25rem, 5rem);
-  line-height: 0.98;
+  font-size: clamp(1.9rem, 3.5vw + 1rem, 4.5rem);
+  line-height: 1.08;
   color: var(--text-dark);
   margin-bottom: 32px;
-  letter-spacing: -0.06em;
-  overflow-wrap: anywhere;
-  word-wrap: break-word;
-  hyphens: auto;
+  letter-spacing: -0.04em;
+  overflow-wrap: break-word;
+  word-break: normal;
+  hyphens: none;
 }
 
 .hero-title .italic-accent {
@@ -425,8 +425,9 @@ img { max-width: 100%; height: auto; display: block; }
   display: block;
   font-weight: 700;
   letter-spacing: -0.04em;
-  overflow-wrap: anywhere;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: normal;
+  hyphens: none;
   max-width: 100%;
 }
 
@@ -454,23 +455,125 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 .hero--home {
-  background: var(--bg-light);
-  padding: 88px 0 96px;
-  border-bottom: 1px solid var(--border);
+  background: linear-gradient(140deg, #051a2e 0%, #082a4d 52%, #0d4f8b 100%);
+  padding: 100px 0 108px;
+  border-bottom: none;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero--home::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+  background-size: 44px 44px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero--home::after {
+  content: '';
+  position: absolute;
+  bottom: -120px;
+  right: -80px;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle, rgba(26,109,181,0.4) 0%, transparent 65%);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .hero--home .container {
   grid-template-columns: 1fr;
+  position: relative;
+  z-index: 1;
 }
 
 .hero--home .hero-content {
-  max-width: 640px;
+  max-width: 660px;
 }
 
 .hero--home .hero-title {
   font-family: var(--font-display);
   font-weight: 700;
   letter-spacing: -0.04em;
+  color: var(--white);
+}
+
+.hero--home .hero-title .italic-accent {
+  color: var(--green-accent);
+}
+
+.hero--home .hero-description {
+  color: rgba(255,255,255,0.72);
+}
+
+.hero-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--green-accent);
+  background: rgba(108,180,228,0.12);
+  border: 1px solid rgba(108,180,228,0.28);
+  padding: 7px 16px;
+  border-radius: 999px;
+  margin-bottom: 28px;
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-top: 40px;
+}
+
+.btn-hero-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--white);
+  color: var(--primary-dark);
+  border: none;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.3px;
+  padding: 14px 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.btn-hero-primary:hover {
+  background: rgba(255,255,255,0.88);
+}
+
+.btn-hero-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: rgba(255,255,255,0.85);
+  border: 1.5px solid rgba(255,255,255,0.3);
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.3px;
+  padding: 14px 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.btn-hero-secondary:hover {
+  border-color: rgba(255,255,255,0.6);
+  background: rgba(255,255,255,0.08);
 }
 
 /* ─────────────── HOME: RESEARCH + PROGRAMS ─────────────── */
@@ -538,7 +641,7 @@ img { max-width: 100%; height: auto; display: block; }
   width: 40px;
   height: 40px;
   border-radius: 8px;
-  background: #ecfdf5;
+  background: rgba(13,79,139,0.08);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -853,6 +956,14 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 @media (max-width: 1024px) {
+  .home-research-grid,
+  .home-programs-grid,
+  .publication-cards-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
   .home-research-grid,
   .home-programs-grid,
   .publication-cards-grid {
@@ -1844,7 +1955,10 @@ noscript + * .fade-in,
 @media (max-width: 768px) {
   .container { padding: 0 20px; }
   .hero { padding: 40px 0 60px; }
-  .hero--home { padding: 36px 0 48px; }
+  .hero--home { padding: 60px 0 72px; }
+  .hero-actions { flex-direction: column; align-items: stretch; }
+  .btn-hero-primary,
+  .btn-hero-secondary { text-align: center; justify-content: center; }
   .home-section { padding: 56px 0; }
   .home-programs { padding-bottom: 22px; }
   .home-section-header { margin-bottom: 32px; }

--- a/dev/index.html
+++ b/dev/index.html
@@ -48,6 +48,7 @@
   <section class="hero hero--home">
     <div class="container">
       <div class="hero-content">
+        <p class="hero-badge">Vancouver Centre for Responsible AI</p>
         <h1 class="hero-title">
           Safety, Sustainability,
           <span class="italic-accent">&amp; Ethics</span>
@@ -58,6 +59,10 @@
           and advocate across three pillars so that the people most affected by
           AI have a seat at the table.
         </p>
+        <div class="hero-actions">
+          <a href="about.html" class="btn btn-hero-primary">About VCASSE</a>
+          <a href="publications.html" class="btn btn-hero-secondary">Read our work</a>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
- Replace flat light-blue hero with dark navy gradient (140deg, #051a2e → #0d4f8b)
- Add subtle grid-line overlay and radial glow via CSS pseudo-elements
- Add hero badge pill and two CTA buttons (About VCASSE / Read our work)
- Fix hero title hyphenation: change hyphens:auto → none, overflow-wrap:anywhere → break-word
- Reduce hero-title clamp minimum (2.25rem → 1.9rem) so "Sustainability," wraps at word boundary not mid-word
- Override hero title / accent colours to white / #6cb4e4 on dark background
- Update card icon background from green tint to brand-blue tint
- Change grid collapse: 2-col at ≤1024px, 1-col only at ≤640px (was 1-col at ≤1024px)
- Stack hero CTA buttons vertically on mobile

https://claude.ai/code/session_01Ehy4cjPjpH3ujG7keaChnJ