### PR TITLE
Redesign home and add pillar publications pages

### DIFF
--- a/dev/contact.html
+++ b/dev/contact.html
@@ -43,12 +43,12 @@
   <section class="page-hero">
     <div class="container">
       <div class="page-hero-content">
-        <div class="section-label">REACH OUT</div>
+        <div class="section-label">Contact</div>
         <h1 class="page-hero-title">
           Get in
-          <span class="italic-accent">Touch</span>
+          <span class="italic-accent">touch</span>
         </h1>
-        <p class="page-hero-description">Whether you're a researcher, policymaker, journalist, or prospective collaborator, we'd love to hear from you. Our team is based in Vancouver, BC and collaborates globally.</p>
+        <p class="page-hero-description">Researcher, policymaker, journalist, collaborator &mdash; if AI affects your work or community, we'd like to hear from you. Our team is based in Vancouver, BC and collaborates with partners across the country and beyond.</p>
         <ul class="page-hero-quicklinks" aria-label="Quick contact options">
           <li><a href="#contact-form">Send a message</a></li>
           <li><a href="mailto:info@vcasse.org">Email us</a></li>
@@ -70,43 +70,45 @@
           <h3>Contact information</h3>
           <p>We read every message. Most enquiries get a first response within two business days. Time-sensitive media requests are flagged for same-day reply.</p>
 
-          <div class="contact-detail">
-            <div class="contact-detail-icon">
-              <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
+          <div class="contact-detail-grid">
+            <div class="contact-detail">
+              <div class="contact-detail-icon">
+                <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
+              </div>
+              <div>
+                <h4>General &amp; partnerships</h4>
+                <p><a href="mailto:info@vcasse.org">info@vcasse.org</a></p>
+              </div>
             </div>
-            <div>
-              <h4>General &amp; partnerships</h4>
-              <p><a href="mailto:info@vcasse.org">info@vcasse.org</a></p>
-            </div>
-          </div>
 
-          <div class="contact-detail">
-            <div class="contact-detail-icon">
-              <svg viewBox="0 0 24 24"><path d="M12 1a4 4 0 0 0-4 4v6a4 4 0 0 0 8 0V5a4 4 0 0 0-4-4zm6 10a6 6 0 0 1-12 0H4a8 8 0 0 0 7 7.93V22h2v-3.07A8 8 0 0 0 20 11h-2z"/></svg>
+            <div class="contact-detail">
+              <div class="contact-detail-icon">
+                <svg viewBox="0 0 24 24"><path d="M12 1a4 4 0 0 0-4 4v6a4 4 0 0 0 8 0V5a4 4 0 0 0-4-4zm6 10a6 6 0 0 1-12 0H4a8 8 0 0 0 7 7.93V22h2v-3.07A8 8 0 0 0 20 11h-2z"/></svg>
+              </div>
+              <div>
+                <h4>Media enquiries</h4>
+                <p><a href="mailto:media@vcasse.org">media@vcasse.org</a> &middot; same-day reply when possible</p>
+              </div>
             </div>
-            <div>
-              <h4>Media enquiries</h4>
-              <p><a href="mailto:media@vcasse.org">media@vcasse.org</a> &middot; same-day response when possible</p>
-            </div>
-          </div>
 
-          <div class="contact-detail">
-            <div class="contact-detail-icon">
-              <svg viewBox="0 0 24 24"><path d="M21 7l-9 6L3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7zm-9 4l9-6H3l9 6z"/></svg>
+            <div class="contact-detail">
+              <div class="contact-detail-icon">
+                <svg viewBox="0 0 24 24"><path d="M21 7l-9 6L3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7zm-9 4l9-6H3l9 6z"/></svg>
+              </div>
+              <div>
+                <h4>Research collaborations</h4>
+                <p><a href="mailto:research@vcasse.org">research@vcasse.org</a></p>
+              </div>
             </div>
-            <div>
-              <h4>Research collaborations</h4>
-              <p><a href="mailto:research@vcasse.org">research@vcasse.org</a> &middot; safety, sustainability, ethics</p>
-            </div>
-          </div>
 
-          <div class="contact-detail">
-            <div class="contact-detail-icon">
-              <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-            </div>
-            <div>
-              <h4>Where we work</h4>
-              <p>Vancouver, BC &middot; on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
+            <div class="contact-detail">
+              <div class="contact-detail-icon">
+                <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+              </div>
+              <div>
+                <h4>Where we work</h4>
+                <p>Vancouver, BC &middot; on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
+              </div>
             </div>
           </div>
 

--- a/dev/contact.html
+++ b/dev/contact.html
@@ -43,14 +43,10 @@
   <section class="page-hero">
     <div class="container">
       <div class="page-hero-content">
-        <div class="section-label">Contact</div>
-        <h1 class="page-hero-title">
-          Get in
-          <span class="italic-accent">touch</span>
-        </h1>
-        <p class="page-hero-description">Researcher, policymaker, journalist, collaborator &mdash; if AI affects your work or community, we'd like to hear from you. Our team is based in Vancouver, BC and collaborates with partners across the country and beyond.</p>
+        <h1 class="page-hero-title">Get in touch</h1>
+        <p class="page-hero-description">If you've got a question, an idea, or a story we should know about, write to us. We're based in Vancouver and read everything that comes in.</p>
         <ul class="page-hero-quicklinks" aria-label="Quick contact options">
-          <li><a href="#contact-form">Send a message</a></li>
+          <li><a href="#contact-form">Use the form</a></li>
           <li><a href="mailto:info@vcasse.org">Email us</a></li>
           <li><a href="#contact-faq">FAQ</a></li>
         </ul>
@@ -67,61 +63,49 @@
     <div class="container">
       <div class="contact-grid">
         <div class="contact-info">
-          <h3>Contact information</h3>
-          <p>We read every message. Most enquiries get a first response within two business days. Time-sensitive media requests are flagged for same-day reply.</p>
+          <h3>Where to write</h3>
+          <p>Pick the closest match. Most messages get a reply in a couple of business days; press queries we try to handle the same day.</p>
 
           <div class="contact-detail-grid">
             <div class="contact-detail">
-              <div class="contact-detail-icon">
-                <svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg>
-              </div>
               <div>
-                <h4>General &amp; partnerships</h4>
+                <h4>General</h4>
                 <p><a href="mailto:info@vcasse.org">info@vcasse.org</a></p>
               </div>
             </div>
 
             <div class="contact-detail">
-              <div class="contact-detail-icon">
-                <svg viewBox="0 0 24 24"><path d="M12 1a4 4 0 0 0-4 4v6a4 4 0 0 0 8 0V5a4 4 0 0 0-4-4zm6 10a6 6 0 0 1-12 0H4a8 8 0 0 0 7 7.93V22h2v-3.07A8 8 0 0 0 20 11h-2z"/></svg>
-              </div>
               <div>
-                <h4>Media enquiries</h4>
-                <p><a href="mailto:media@vcasse.org">media@vcasse.org</a> &middot; same-day reply when possible</p>
+                <h4>Press</h4>
+                <p><a href="mailto:media@vcasse.org">media@vcasse.org</a></p>
               </div>
             </div>
 
             <div class="contact-detail">
-              <div class="contact-detail-icon">
-                <svg viewBox="0 0 24 24"><path d="M21 7l-9 6L3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7zm-9 4l9-6H3l9 6z"/></svg>
-              </div>
               <div>
-                <h4>Research collaborations</h4>
+                <h4>Research</h4>
                 <p><a href="mailto:research@vcasse.org">research@vcasse.org</a></p>
               </div>
             </div>
 
             <div class="contact-detail">
-              <div class="contact-detail-icon">
-                <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-              </div>
               <div>
-                <h4>Where we work</h4>
-                <p>Vancouver, BC &middot; on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
+                <h4>Where we are</h4>
+                <p>Vancouver, BC, on the unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
               </div>
             </div>
           </div>
 
           <div class="contact-info-card">
             <p class="contact-info-card-kicker">Office hours</p>
-            <p class="contact-info-card-line">Mon &ndash; Fri &middot; 9:00 &ndash; 17:00 PT</p>
-            <p class="contact-info-card-meta">Closed on statutory holidays. Public events are listed on the <a href="events.html">events page</a>.</p>
+            <p class="contact-info-card-line">Monday to Friday, 9 to 5 Pacific.</p>
+            <p class="contact-info-card-meta">Closed on stat holidays. Public events are over on the <a href="events.html">events page</a>.</p>
           </div>
         </div>
 
         <div class="contact-form" id="contact-form">
           <h3 class="contact-form-title">Send a message</h3>
-          <p class="contact-form-lede">Tell us a little about why you're reaching out. We'll route your message to the right person on our team.</p>
+          <p class="contact-form-lede">A few details so we can route it to the right person.</p>
           <form action="#" method="POST">
             <div class="form-row">
               <div class="form-group">
@@ -168,30 +152,28 @@
   <section class="contact-faq" id="contact-faq" aria-labelledby="contact-faq-heading">
     <div class="container">
       <header class="home-section-header">
-        <p class="home-section-kicker">FAQ</p>
-        <h2 id="contact-faq-heading" class="home-section-title">Common questions</h2>
-        <p class="home-section-lead">Quick answers before you write &mdash; if anything here doesn't fit your situation, please send us a message.</p>
+        <h2 id="contact-faq-heading" class="home-section-title">A few common questions</h2>
       </header>
       <div class="contact-faq-list">
         <details class="contact-faq-item" open>
-          <summary>How quickly will I get a reply?</summary>
-          <p>Most enquiries receive a first response within two business days. Media enquiries are flagged for same-day attention when possible.</p>
+          <summary>How quickly will I hear back?</summary>
+          <p>Usually within a couple of business days. Press queries we try to answer same-day.</p>
         </details>
         <details class="contact-faq-item">
-          <summary>Can VCASSE speak at our event or panel?</summary>
-          <p>Yes &mdash; we accept speaking requests across safety, sustainability, and ethics topics. Use the form above and select <em>Speaking request</em>, and please include the date, format, and audience.</p>
+          <summary>Can someone from VCASSE speak at our event?</summary>
+          <p>Often, yes. Use the form, pick "Speaking request" from the dropdown, and tell us the date, format, and audience.</p>
         </details>
         <details class="contact-faq-item">
           <summary>How do I propose a research collaboration?</summary>
-          <p>Reach out via <a href="mailto:research@vcasse.org">research@vcasse.org</a> with a short note describing the question, the data or partner involved, and the timeline. We'll set up a 30-minute scoping call.</p>
+          <p>Email <a href="mailto:research@vcasse.org">research@vcasse.org</a> with the question you're working on, who else is involved, and rough timing. We'll set up a short call from there.</p>
         </details>
         <details class="contact-faq-item">
-          <summary>Are you taking on student researchers or interns?</summary>
-          <p>We work with student researchers from Vancouver-area universities on a rolling basis. Send your CV and a paragraph on what you'd like to work on.</p>
+          <summary>Do you take on student researchers?</summary>
+          <p>Yes, on a rolling basis, mostly with students at Vancouver-area schools. Send a CV and a paragraph on what you'd want to dig into.</p>
         </details>
         <details class="contact-faq-item">
-          <summary>Where can I read your published work?</summary>
-          <p>All briefs, explainers, and research notes are on the <a href="publications.html">publications page</a>, filterable by pillar, tag, and date.</p>
+          <summary>Where can I read what you've published?</summary>
+          <p>It's all on the <a href="publications.html">publications page</a>, with filters by topic and tag.</p>
         </details>
       </div>
     </div>

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -474,17 +474,7 @@ img { max-width: 100%; height: auto; display: block; }
   z-index: 0;
 }
 
-.hero--home::after {
-  content: '';
-  position: absolute;
-  bottom: -120px;
-  right: -80px;
-  width: 520px;
-  height: 520px;
-  background: radial-gradient(circle, rgba(26,109,181,0.4) 0%, transparent 65%);
-  pointer-events: none;
-  z-index: 0;
-}
+.hero--home::after { content: none; }
 
 .hero--home .container {
   grid-template-columns: 1fr;
@@ -799,45 +789,34 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 .publication-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--text-muted);
+}
+
+.publication-pill::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
   display: inline-block;
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid transparent;
+  flex-shrink: 0;
 }
 
-.publication-pill--safety {
-  color: #065f46;
-  background: #d1fae5;
-  border-color: #a7f3d0;
-}
-
-.publication-pill--sustainability {
-  color: #0f766e;
-  background: #ccfbf1;
-  border-color: #99f6e4;
-}
-
-.publication-pill--ethics {
-  color: #1d4ed8;
-  background: #dbeafe;
-  border-color: #bfdbfe;
-}
-
-.publication-pill--vcasse {
-  color: #0d4f8b;
-  background: #cfe2f3;
-  border-color: #6cb4e4;
-}
-
-.publication-pill--community {
-  color: #9a3412;
-  background: #ffedd5;
-  border-color: #fdba74;
-}
+.publication-pill--safety { color: #047857; }
+.publication-pill--sustainability { color: #0f766e; }
+.publication-pill--ethics { color: #1d4ed8; }
+.publication-pill--vcasse { color: var(--primary); }
+.publication-pill--community { color: #9a3412; }
 
 .home-publications-cta {
   margin-top: 24px;
@@ -945,14 +924,11 @@ img { max-width: 100%; height: auto; display: block; }
 
 .badge-soon {
   display: inline-block;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.95);
-  background: var(--green-accent);
-  padding: 6px 12px;
-  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  padding: 0;
+  background: transparent;
 }
 
 @media (max-width: 1024px) {
@@ -2492,13 +2468,7 @@ noscript + * .fade-in,
   transform: scale(1.04);
 }
 
-.publication-card-cover .publication-pill {
-  position: absolute;
-  top: 14px;
-  left: 14px;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(4px);
-}
+/* legacy: pill no longer sits on the cover */
 
 .publication-card-body {
   display: flex;
@@ -3163,32 +3133,23 @@ noscript + * .fade-in,
   }
 }
 
-/* ─────────────── HOME PUBLICATIONS — FEATURED LEAD CARD ─────────────── */
+/* ─────────────── HOME PUBLICATIONS — FEATURED LEAD ─────────────── */
 
 .home-publications-featured {
   display: grid;
-  grid-template-columns: 1.15fr 1fr;
-  gap: 28px;
-  background: var(--bg-card);
-  border: 1px solid rgba(15, 23, 42, 0.07);
-  border-radius: 20px;
-  overflow: hidden;
-  margin-bottom: 28px;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-}
-
-.home-publications-featured:hover {
-  border-color: var(--primary);
-  box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.28);
-  transform: translateY(-2px);
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 36px;
+  align-items: center;
+  margin-bottom: 56px;
+  padding-bottom: 40px;
+  border-bottom: 1px solid var(--border);
 }
 
 .home-publications-featured-cover {
-  position: relative;
   display: block;
-  background: var(--bg-page);
-  min-height: 280px;
   overflow: hidden;
+  background: var(--bg-page);
+  aspect-ratio: 4 / 3;
 }
 
 .home-publications-featured-cover img {
@@ -3196,36 +3157,15 @@ noscript + * .fade-in,
   height: 100%;
   object-fit: cover;
   display: block;
-  transition: transform 0.4s ease;
-}
-
-.home-publications-featured:hover .home-publications-featured-cover img {
-  transform: scale(1.03);
-}
-
-.home-publications-featured-cover .publication-pill {
-  position: absolute;
-  top: 18px;
-  left: 18px;
-  background: rgba(255, 255, 255, 0.94);
-  backdrop-filter: blur(6px);
 }
 
 .home-publications-featured-body {
-  padding: 32px 32px 28px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
 }
 
 .home-publications-featured-body .home-publications-featured-kicker {
-  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
 .home-publications-featured-body h3 {
@@ -3234,7 +3174,7 @@ noscript + * .fade-in,
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--text-dark);
-  line-height: 1.15;
+  line-height: 1.2;
   margin-bottom: 14px;
 }
 
@@ -3251,52 +3191,35 @@ noscript + * .fade-in,
   font-size: 1rem;
   line-height: 1.6;
   color: var(--text-body);
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
 .home-publications-featured-meta {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
   font-size: 13px;
   color: var(--text-muted);
-  margin-bottom: 20px;
-}
-
-.publication-card:hover {
-  box-shadow: 0 14px 30px -20px rgba(15, 23, 42, 0.22);
-  transform: translateY(-2px);
+  margin-bottom: 18px;
 }
 
 @media (max-width: 768px) {
   .home-publications-featured {
     grid-template-columns: 1fr;
+    gap: 22px;
+    padding-bottom: 32px;
+    margin-bottom: 36px;
   }
   .home-publications-featured-cover {
-    min-height: 200px;
     aspect-ratio: 16 / 9;
-  }
-  .home-publications-featured-body {
-    padding: 24px 22px 26px;
   }
 }
 
 /* ─────────────── HOME CONTACT STRIP ─────────────── */
 
-.home-contact {
-  position: relative;
-}
-
-.home-contact-card {
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap: 32px;
-  background: var(--bg-card);
-  border: 1px solid rgba(15, 23, 42, 0.07);
-  border-radius: 20px;
-  padding: 40px;
-  align-items: stretch;
+.home-contact-info {
+  max-width: 640px;
 }
 
 .home-contact-info h2 {
@@ -3313,8 +3236,7 @@ noscript + * .fade-in,
   font-size: 1rem;
   line-height: 1.65;
   color: var(--text-body);
-  margin-bottom: 22px;
-  max-width: 44ch;
+  margin-bottom: 24px;
 }
 
 .home-contact-emails {
@@ -3322,85 +3244,42 @@ noscript + * .fade-in,
   display: grid;
   gap: 14px;
   margin-bottom: 22px;
+  padding: 0;
 }
 
 .home-contact-emails li {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px;
 }
 
 .home-contact-emails .home-contact-label {
-  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+  font-size: 13px;
   color: var(--text-muted);
+  min-width: 64px;
 }
 
 .home-contact-emails a {
   font-size: 1rem;
-  font-weight: 600;
   color: var(--primary);
   text-decoration: none;
-  transition: color 0.2s ease;
+  font-weight: 500;
 }
 
 .home-contact-emails a:hover {
-  color: var(--primary-dark);
   text-decoration: underline;
 }
 
-.home-contact-location {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
+.home-contact-aside {
+  font-size: 14px;
   color: var(--text-muted);
 }
 
-.home-contact-location svg {
-  width: 16px;
-  height: 16px;
-  fill: currentColor;
-}
-
-.home-contact-cta {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  background: var(--bg-page);
-  border-radius: 16px;
-  padding: 28px;
-  border: 1px solid var(--border);
-}
-
-.home-contact-cta h3 {
-  font-family: var(--font-display);
-  font-size: 1.25rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text-dark);
-  margin-bottom: 10px;
-}
-
-.home-contact-cta p {
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--text-body);
-  margin-bottom: 18px;
-}
-
-@media (max-width: 768px) {
-  .home-contact-card {
-    grid-template-columns: 1fr;
-    padding: 28px 22px;
-    gap: 24px;
-  }
-  .home-contact-cta {
-    padding: 22px;
-  }
+.home-contact-aside a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* ─────────────── PUBLICATIONS HERO BREADCRUMB (pillar pages) ─────────────── */

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -1498,6 +1498,23 @@ img { max-width: 100%; height: auto; display: block; }
 .contact-info h3 { font-size: 20px; font-weight: 700; color: var(--text-dark); margin-bottom: 8px; }
 .contact-info p { font-size: 15px; line-height: 1.7; color: var(--text-body); margin-bottom: 32px; }
 
+.contact-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px 28px;
+  margin-bottom: 24px;
+}
+
+.contact-detail-grid .contact-detail {
+  margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+  .contact-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .contact-detail {
   display: flex;
   align-items: flex-start;
@@ -2169,7 +2186,7 @@ noscript + * .fade-in,
     transform: rotate(45deg);
   }
 
-  /* Submenu — indented, smaller, sub-numbered via counter */
+  /* Submenu — indented, sub-numbered via counter, sized for legible mobile tap targets */
   .nav-links .nav-dropdown-menu {
     position: relative !important;
     left: auto;
@@ -2178,7 +2195,7 @@ noscript + * .fade-in,
     transform: none;
     width: 100%;
     min-width: 0;
-    list-style: none; padding: 0 0 6px 34px; margin: 0;
+    list-style: none; padding: 4px 0 10px clamp(20px, 5vw, 28px); margin: 0;
     background: transparent; border: none; box-shadow: none;
     max-height: 0; overflow: hidden;
     opacity: 0; visibility: hidden;
@@ -2186,23 +2203,23 @@ noscript + * .fade-in,
     counter-reset: submenu;
   }
   .nav-links .nav-dropdown.is-open > .nav-dropdown-menu {
-    max-height: 220px; opacity: 1; visibility: visible;
+    max-height: 420px; opacity: 1; visibility: visible;
     transition: max-height .4s ease, opacity .3s ease .1s, visibility 0s linear 0s;
   }
   .nav-links .nav-dropdown-menu li { counter-increment: submenu; border: none; }
   .nav-links .nav-dropdown-menu a {
-    display: flex; gap: 10px; padding: 4px 0;
+    display: flex; gap: 12px; padding: 10px 0;
     align-items: baseline;
     width: 100%;
     border-radius: 0;
-    font-weight: 400;
-    font-family: var(--font-sans); font-size: 13px;
-    color: var(--slate-professional, #374151); text-decoration: none;
+    font-weight: 500;
+    font-family: var(--font-sans); font-size: clamp(1rem, 3.6vw, 1.15rem);
+    color: var(--mobile-menu-ink, #082a4d); text-decoration: none;
   }
   .nav-links .nav-dropdown-menu a::before {
     content: counter(menu, decimal-leading-zero) "." counter(submenu);
     font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px; color: var(--muted, #6b7280); flex: 0 0 24px;
+    font-size: 12px; color: var(--muted, #6b7280); flex: 0 0 30px;
   }
   .nav-links .nav-dropdown-menu a.active {
     background: transparent;
@@ -3145,3 +3162,264 @@ noscript + * .fade-in,
     margin-top: 16px;
   }
 }
+
+/* ─────────────── HOME PUBLICATIONS — FEATURED LEAD CARD ─────────────── */
+
+.home-publications-featured {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 28px;
+  background: var(--bg-card);
+  border: 1px solid rgba(15, 23, 42, 0.07);
+  border-radius: 20px;
+  overflow: hidden;
+  margin-bottom: 28px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.home-publications-featured:hover {
+  border-color: var(--primary);
+  box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.28);
+  transform: translateY(-2px);
+}
+
+.home-publications-featured-cover {
+  position: relative;
+  display: block;
+  background: var(--bg-page);
+  min-height: 280px;
+  overflow: hidden;
+}
+
+.home-publications-featured-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.home-publications-featured:hover .home-publications-featured-cover img {
+  transform: scale(1.03);
+}
+
+.home-publications-featured-cover .publication-pill {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(6px);
+}
+
+.home-publications-featured-body {
+  padding: 32px 32px 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.home-publications-featured-body .home-publications-featured-kicker {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.home-publications-featured-body h3 {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-dark);
+  line-height: 1.15;
+  margin-bottom: 14px;
+}
+
+.home-publications-featured-body h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.home-publications-featured-body h3 a:hover {
+  color: var(--primary);
+}
+
+.home-publications-featured-body p {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text-body);
+  margin-bottom: 16px;
+}
+
+.home-publications-featured-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+
+.publication-card:hover {
+  box-shadow: 0 14px 30px -20px rgba(15, 23, 42, 0.22);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 768px) {
+  .home-publications-featured {
+    grid-template-columns: 1fr;
+  }
+  .home-publications-featured-cover {
+    min-height: 200px;
+    aspect-ratio: 16 / 9;
+  }
+  .home-publications-featured-body {
+    padding: 24px 22px 26px;
+  }
+}
+
+/* ─────────────── HOME CONTACT STRIP ─────────────── */
+
+.home-contact {
+  position: relative;
+}
+
+.home-contact-card {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 32px;
+  background: var(--bg-card);
+  border: 1px solid rgba(15, 23, 42, 0.07);
+  border-radius: 20px;
+  padding: 40px;
+  align-items: stretch;
+}
+
+.home-contact-info h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-dark);
+  margin-bottom: 14px;
+  line-height: 1.15;
+}
+
+.home-contact-info > p {
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--text-body);
+  margin-bottom: 22px;
+  max-width: 44ch;
+}
+
+.home-contact-emails {
+  list-style: none;
+  display: grid;
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.home-contact-emails li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.home-contact-emails .home-contact-label {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.home-contact-emails a {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--primary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.home-contact-emails a:hover {
+  color: var(--primary-dark);
+  text-decoration: underline;
+}
+
+.home-contact-location {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.home-contact-location svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.home-contact-cta {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: var(--bg-page);
+  border-radius: 16px;
+  padding: 28px;
+  border: 1px solid var(--border);
+}
+
+.home-contact-cta h3 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-dark);
+  margin-bottom: 10px;
+}
+
+.home-contact-cta p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-body);
+  margin-bottom: 18px;
+}
+
+@media (max-width: 768px) {
+  .home-contact-card {
+    grid-template-columns: 1fr;
+    padding: 28px 22px;
+    gap: 24px;
+  }
+  .home-contact-cta {
+    padding: 22px;
+  }
+}
+
+/* ─────────────── PUBLICATIONS HERO BREADCRUMB (pillar pages) ─────────────── */
+
+.publications-hero-crumb {
+  margin-top: 24px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.publications-hero-crumb a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.publications-hero-crumb a:hover {
+  color: var(--primary-dark);
+  text-decoration: underline;
+}
+

--- a/dev/ethics.html
+++ b/dev/ethics.html
@@ -113,6 +113,9 @@
         <h2 class="home-section-title">Latest ethics publications</h2>
       </header>
       <div class="publication-cards-grid" data-related-publications data-pillar="ethics" data-limit="2"></div>
+      <div class="home-publications-cta">
+        <a class="btn btn-secondary" href="publications/ethics.html">View all ethics publications <span aria-hidden="true">→</span></a>
+      </div>
     </div>
   </section>
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -67,6 +67,77 @@
     </div>
   </section>
 
+  <!-- PUBLICATIONS (featured + 3-up) -->
+  <section class="home-section home-publications fade-in" aria-labelledby="home-publications-heading">
+    <div class="container">
+      <header class="home-section-header">
+        <p class="home-section-kicker">Publications</p>
+        <h2 id="home-publications-heading" class="home-section-title">What we're publishing</h2>
+        <p class="home-section-lead">Practical research, policy briefs, and explainers — bringing AI news and accountability to Vancouver, with public events to follow.</p>
+      </header>
+
+      <article class="home-publications-featured">
+        <a class="home-publications-featured-cover" href="publications/safety-evaluations-public-interest.html" aria-label="Read Practical AI Safety Evaluations for Public-Interest Teams">
+          <img src="img/publications/safety-evaluations.svg" alt="" loading="lazy" decoding="async">
+          <span class="publication-pill publication-pill--safety">Safety</span>
+        </a>
+        <div class="home-publications-featured-body">
+          <p class="home-publications-featured-kicker">Latest publication</p>
+          <h3><a href="publications/safety-evaluations-public-interest.html">Practical AI Safety Evaluations for Public-Interest Teams</a></h3>
+          <div class="home-publications-featured-meta">
+            <span>Mar 15, 2026</span>
+            <span aria-hidden="true">·</span>
+            <span>7 min read</span>
+            <span aria-hidden="true">·</span>
+            <span>Dr. Mei Tanaka, Priya Sandhu</span>
+          </div>
+          <p>A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
+          <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read publication <span aria-hidden="true">→</span></a>
+        </div>
+      </article>
+
+      <div class="publication-cards-grid">
+        <article class="publication-card">
+          <div class="publication-card-meta">
+            <span class="publication-pill publication-pill--sustainability">Sustainability</span>
+            <span>Feb 27, 2026</span>
+            <span>6 min read</span>
+          </div>
+          <h3>A Sustainability Checklist for AI Procurement</h3>
+          <p>How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
+          <ul class="publication-tags"><li>Climate</li><li>Procurement</li><li>Infrastructure</li></ul>
+          <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read publication <span aria-hidden="true">→</span></a>
+        </article>
+        <article class="publication-card">
+          <div class="publication-card-meta">
+            <span class="publication-pill publication-pill--ethics">Ethics</span>
+            <span>Jan 31, 2026</span>
+            <span>8 min read</span>
+          </div>
+          <h3>Participatory Ethics in Municipal AI Decisions</h3>
+          <p>Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
+          <ul class="publication-tags"><li>Inclusion</li><li>Policy</li><li>Public Deliberation</li></ul>
+          <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read publication <span aria-hidden="true">→</span></a>
+        </article>
+        <article class="publication-card">
+          <div class="publication-card-meta">
+            <span class="publication-pill publication-pill--safety">Safety</span>
+            <span>Dec 12, 2025</span>
+            <span>5 min read</span>
+          </div>
+          <h3>Incident Reporting Playbook for Responsible AI Teams</h3>
+          <p>A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p>
+          <ul class="publication-tags"><li>Operations</li><li>Incident Response</li><li>Monitoring</li></ul>
+          <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
+        </article>
+      </div>
+
+      <div class="home-publications-cta">
+        <a class="btn btn-secondary" href="publications.html">View all publications <span aria-hidden="true">→</span></a>
+      </div>
+    </div>
+  </section>
+
   <!-- RESEARCH -->
   <section class="home-section home-research fade-in" aria-labelledby="home-research-heading">
     <div class="container">
@@ -132,51 +203,38 @@
     </div>
   </section>
 
-  <!-- BLOG / PUBLICATIONS -->
-  <section class="home-section home-publications fade-in" aria-labelledby="home-publications-heading">
+  <!-- HOME CONTACT STRIP -->
+  <section class="home-section home-contact fade-in" aria-labelledby="home-contact-heading">
     <div class="container">
-      <header class="home-section-header">
-        <p class="home-section-kicker">Blog</p>
-        <h2 id="home-publications-heading" class="home-section-title">Publications across all pillars</h2>
-        <p class="home-section-lead">Notes, briefs, and explainers from Safety, Sustainability, and Ethics.</p>
-      </header>
-      <div class="publication-cards-grid">
-        <article class="publication-card publication-card--compact">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--safety">Safety</span>
-            <span>Mar 15, 2026</span>
-            <span>7 min read</span>
-          </div>
-          <h3>Practical AI Safety Evaluations for Public-Interest Teams</h3>
-          <p>A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
-          <ul class="publication-tags"><li>Evaluations</li><li>Risk</li><li>Governance</li></ul>
-          <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-        <article class="publication-card publication-card--compact">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--sustainability">Sustainability</span>
-            <span>Feb 27, 2026</span>
-            <span>6 min read</span>
-          </div>
-          <h3>A Sustainability Checklist for AI Procurement</h3>
-          <p>How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
-          <ul class="publication-tags"><li>Climate</li><li>Procurement</li><li>Infrastructure</li></ul>
-          <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-        <article class="publication-card publication-card--compact">
-          <div class="publication-card-meta">
-            <span class="publication-pill publication-pill--ethics">Ethics</span>
-            <span>Jan 31, 2026</span>
-            <span>8 min read</span>
-          </div>
-          <h3>Participatory Ethics in Municipal AI Decisions</h3>
-          <p>Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
-          <ul class="publication-tags"><li>Inclusion</li><li>Policy</li><li>Public Deliberation</li></ul>
-          <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read publication <span aria-hidden="true">→</span></a>
-        </article>
-      </div>
-      <div class="home-publications-cta">
-        <a class="btn btn-secondary" href="publications.html">View all publications</a>
+      <div class="home-contact-card">
+        <div class="home-contact-info">
+          <p class="home-section-kicker">Contact</p>
+          <h2 id="home-contact-heading">Get in touch</h2>
+          <p>Questions about our research, requests to collaborate, or notes from local journalists — we read everything and reply quickly. We're rooted in Vancouver and focused on bringing AI accountability home.</p>
+          <ul class="home-contact-emails">
+            <li>
+              <span class="home-contact-label">General</span>
+              <a href="mailto:info@vcasse.org">info@vcasse.org</a>
+            </li>
+            <li>
+              <span class="home-contact-label">Media</span>
+              <a href="mailto:media@vcasse.org">media@vcasse.org</a>
+            </li>
+            <li>
+              <span class="home-contact-label">Research</span>
+              <a href="mailto:research@vcasse.org">research@vcasse.org</a>
+            </li>
+          </ul>
+          <span class="home-contact-location">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+            Vancouver, BC, Canada
+          </span>
+        </div>
+        <div class="home-contact-cta">
+          <h3>Send us a message</h3>
+          <p>Have a longer note, a research collaboration, or a media request? Use our full contact form for a written reply within two business days.</p>
+          <a class="btn btn-primary" href="contact.html">Open contact form <span aria-hidden="true">→</span></a>
+        </div>
       </div>
     </div>
   </section>

--- a/dev/index.html
+++ b/dev/index.html
@@ -48,20 +48,20 @@
   <section class="hero hero--home">
     <div class="container">
       <div class="hero-content">
-        <p class="hero-badge">Vancouver Centre for Responsible AI</p>
+        <p class="hero-badge">Vancouver, BC</p>
         <h1 class="hero-title">
-          Safety, Sustainability,
-          <span class="italic-accent">&amp; Ethics</span>
+          Vancouver Centre for AI<br>
+          Safety, Sustainability, and Ethics
         </h1>
 
         <p class="hero-description">
-          Vancouver's dedicated centre for responsible AI. We research, educate,
-          and advocate across three pillars so that the people most affected by
-          AI have a seat at the table.
+          We're a small research and advocacy group based in Vancouver. We write
+          about how AI is being built, how it's being used in public life, and
+          where it's heading.
         </p>
         <div class="hero-actions">
-          <a href="about.html" class="btn btn-hero-primary">About VCASSE</a>
-          <a href="publications.html" class="btn btn-hero-secondary">Read our work</a>
+          <a href="publications.html" class="btn btn-hero-primary">Read the publications</a>
+          <a href="about.html" class="btn btn-hero-secondary">About us</a>
         </div>
       </div>
     </div>
@@ -71,28 +71,26 @@
   <section class="home-section home-publications fade-in" aria-labelledby="home-publications-heading">
     <div class="container">
       <header class="home-section-header">
-        <p class="home-section-kicker">Publications</p>
-        <h2 id="home-publications-heading" class="home-section-title">What we're publishing</h2>
-        <p class="home-section-lead">Practical research, policy briefs, and explainers — bringing AI news and accountability to Vancouver, with public events to follow.</p>
+        <h2 id="home-publications-heading" class="home-section-title">Recent writing</h2>
+        <p class="home-section-lead">Notes, briefs, and longer pieces. We post when we have something worth saying.</p>
       </header>
 
       <article class="home-publications-featured">
         <a class="home-publications-featured-cover" href="publications/safety-evaluations-public-interest.html" aria-label="Read Practical AI Safety Evaluations for Public-Interest Teams">
           <img src="img/publications/safety-evaluations.svg" alt="" loading="lazy" decoding="async">
-          <span class="publication-pill publication-pill--safety">Safety</span>
         </a>
         <div class="home-publications-featured-body">
-          <p class="home-publications-featured-kicker">Latest publication</p>
-          <h3><a href="publications/safety-evaluations-public-interest.html">Practical AI Safety Evaluations for Public-Interest Teams</a></h3>
+          <p class="home-publications-featured-kicker"><span class="publication-pill publication-pill--safety">Safety</span></p>
+          <h3><a href="publications/safety-evaluations-public-interest.html">Practical AI safety evaluations for public-interest teams</a></h3>
+          <p>A working framework for spotting model failure modes before something built with public money goes live.</p>
           <div class="home-publications-featured-meta">
             <span>Mar 15, 2026</span>
             <span aria-hidden="true">·</span>
             <span>7 min read</span>
             <span aria-hidden="true">·</span>
-            <span>Dr. Mei Tanaka, Priya Sandhu</span>
+            <span>Mei Tanaka, Priya Sandhu</span>
           </div>
-          <p>A practical framework for evaluating model failure modes before deployment in civic and public-service contexts.</p>
-          <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read publication <span aria-hidden="true">→</span></a>
+          <a class="modern-card-link" href="publications/safety-evaluations-public-interest.html">Read it <span aria-hidden="true">→</span></a>
         </div>
       </article>
 
@@ -101,39 +99,33 @@
           <div class="publication-card-meta">
             <span class="publication-pill publication-pill--sustainability">Sustainability</span>
             <span>Feb 27, 2026</span>
-            <span>6 min read</span>
           </div>
-          <h3>A Sustainability Checklist for AI Procurement</h3>
-          <p>How organizations can ask better vendor questions around energy use, lifecycle impact, and reporting transparency.</p>
-          <ul class="publication-tags"><li>Climate</li><li>Procurement</li><li>Infrastructure</li></ul>
-          <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read publication <span aria-hidden="true">→</span></a>
+          <h3>A sustainability checklist for AI procurement</h3>
+          <p>What to ask vendors about energy use, hardware lifecycle, and how honestly they report it.</p>
+          <a class="modern-card-link" href="publications/sustainability-procurement-checklist.html">Read it <span aria-hidden="true">→</span></a>
         </article>
         <article class="publication-card">
           <div class="publication-card-meta">
             <span class="publication-pill publication-pill--ethics">Ethics</span>
             <span>Jan 31, 2026</span>
-            <span>8 min read</span>
           </div>
-          <h3>Participatory Ethics in Municipal AI Decisions</h3>
-          <p>Why public-facing AI decisions should include structured resident participation, not only internal review.</p>
-          <ul class="publication-tags"><li>Inclusion</li><li>Policy</li><li>Public Deliberation</li></ul>
-          <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read publication <span aria-hidden="true">→</span></a>
+          <h3>Participatory ethics in municipal AI decisions</h3>
+          <p>If a city decision uses AI, the people it affects should have a way into the process. A look at how that can actually work.</p>
+          <a class="modern-card-link" href="publications/participatory-ethics-municipal-ai.html">Read it <span aria-hidden="true">→</span></a>
         </article>
         <article class="publication-card">
           <div class="publication-card-meta">
             <span class="publication-pill publication-pill--safety">Safety</span>
             <span>Dec 12, 2025</span>
-            <span>5 min read</span>
           </div>
-          <h3>Incident Reporting Playbook for Responsible AI Teams</h3>
-          <p>A simple operational playbook for classifying incidents, escalating quickly, and learning from postmortems.</p>
-          <ul class="publication-tags"><li>Operations</li><li>Incident Response</li><li>Monitoring</li></ul>
-          <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read publication <span aria-hidden="true">→</span></a>
+          <h3>An incident reporting playbook for AI teams</h3>
+          <p>What to do when something goes wrong. Triage, escalation, and a postmortem template you can actually fill in.</p>
+          <a class="modern-card-link" href="publications/incident-reporting-playbook.html">Read it <span aria-hidden="true">→</span></a>
         </article>
       </div>
 
       <div class="home-publications-cta">
-        <a class="btn btn-secondary" href="publications.html">View all publications <span aria-hidden="true">→</span></a>
+        <a class="btn btn-secondary" href="publications.html">All publications <span aria-hidden="true">→</span></a>
       </div>
     </div>
   </section>
@@ -142,34 +134,24 @@
   <section class="home-section home-research fade-in" aria-labelledby="home-research-heading">
     <div class="container">
       <header class="home-section-header">
-        <p class="home-section-kicker">Focus Areas</p>
-        <h2 id="home-research-heading" class="home-section-title">Three pillars of responsible AI</h2>
-        <p class="home-section-lead">Our work spans technical safety, environmental and social sustainability, and the ethical questions that shape who benefits from AI and who bears the risk.</p>
+        <h2 id="home-research-heading" class="home-section-title">What we work on</h2>
+        <p class="home-section-lead">We split the work into three areas. They overlap more than they divide, but the shorthand helps.</p>
       </header>
       <div class="home-research-grid">
         <article class="modern-card">
-          <div class="modern-card-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </div>
           <h3>Safety</h3>
-          <p>Robustness, alignment, and risk-aware deployment so systems behave reliably in the real world.</p>
-          <a class="modern-card-link" href="safety.html">Explore safety <span aria-hidden="true">→</span></a>
+          <p>How AI systems break, how to catch it before they ship, and what to do when something goes wrong in production.</p>
+          <a class="modern-card-link" href="safety.html">More on safety <span aria-hidden="true">→</span></a>
         </article>
         <article class="modern-card">
-          <div class="modern-card-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 3.5 2 6.5c0 5.5-4.5 7-8 7.5z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M6 22c1.5-6.5 6.5-10 11-11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </div>
           <h3>Sustainability</h3>
-          <p>Energy, data, and lifecycle impacts of AI systems in a changing climate and economy.</p>
-          <a class="modern-card-link" href="sustainability.html">Explore sustainability <span aria-hidden="true">→</span></a>
+          <p>The energy, water, and hardware costs of running AI at scale, and what honest reporting looks like.</p>
+          <a class="modern-card-link" href="sustainability.html">More on sustainability <span aria-hidden="true">→</span></a>
         </article>
         <article class="modern-card">
-          <div class="modern-card-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><path d="M12 2v20M4 6h16M7 6l-3 7h6zM17 6l3 7h-6zM9 22h6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </div>
           <h3>Ethics</h3>
-          <p>Justice, governance, and participation so AI serves communities fairly and transparently.</p>
-          <a class="modern-card-link" href="ethics.html">Explore ethics <span aria-hidden="true">→</span></a>
+          <p>Who decides where AI is used, who gets to push back, and how those decisions get made in cities like ours.</p>
+          <a class="modern-card-link" href="ethics.html">More on ethics <span aria-hidden="true">→</span></a>
         </article>
       </div>
     </div>
@@ -179,25 +161,24 @@
   <section class="home-section home-programs fade-in" aria-labelledby="home-programs-heading">
     <div class="container">
       <header class="home-section-header">
-        <p class="home-section-kicker">Programs</p>
-        <h2 id="home-programs-heading" class="home-section-title">Core programs for Vancouver</h2>
-        <p class="home-section-lead">Our programming translates research into practical action through policy support, public dialogue, and city-wide literacy work.</p>
+        <h2 id="home-programs-heading" class="home-section-title">What we're building</h2>
+        <p class="home-section-lead">Three things alongside the writing. All three are in early stages. Get in touch if you want to be part of one.</p>
       </header>
       <div class="home-programs-grid">
         <div class="program-card">
           <h3>Policy briefs</h3>
-          <p>Research-backed briefs for municipal and provincial government so decisions on AI regulation, funding, and services are evidence-led.</p>
-          <span class="badge-soon">Core program</span>
+          <p>Short reads for City Hall and the province on specific AI questions as they come up.</p>
+          <span class="badge-soon">In progress</span>
         </div>
         <div class="program-card">
-          <h3>Community forums and public panels</h3>
-          <p>Regular dialogues that bring together researchers, developers, policymakers, and community members around high-impact AI issues.</p>
-          <span class="badge-soon">Core program</span>
+          <h3>Public events</h3>
+          <p>Panels and conversations that put researchers, builders, and residents in the same room.</p>
+          <span class="badge-soon">Starting 2026</span>
         </div>
         <div class="program-card">
-          <h3>Vancouver AI literacy programs</h3>
-          <p>Local education programs covering what AI is, how it works, and how it affects privacy, employment, environment, and daily life.</p>
-          <span class="badge-soon">Core program</span>
+          <h3>AI literacy in the city</h3>
+          <p>Local sessions on what AI actually is, and where you're already running into it at work, at school, and in city services.</p>
+          <span class="badge-soon">Planning</span>
         </div>
       </div>
     </div>
@@ -206,35 +187,24 @@
   <!-- HOME CONTACT STRIP -->
   <section class="home-section home-contact fade-in" aria-labelledby="home-contact-heading">
     <div class="container">
-      <div class="home-contact-card">
-        <div class="home-contact-info">
-          <p class="home-section-kicker">Contact</p>
-          <h2 id="home-contact-heading">Get in touch</h2>
-          <p>Questions about our research, requests to collaborate, or notes from local journalists — we read everything and reply quickly. We're rooted in Vancouver and focused on bringing AI accountability home.</p>
-          <ul class="home-contact-emails">
-            <li>
-              <span class="home-contact-label">General</span>
-              <a href="mailto:info@vcasse.org">info@vcasse.org</a>
-            </li>
-            <li>
-              <span class="home-contact-label">Media</span>
-              <a href="mailto:media@vcasse.org">media@vcasse.org</a>
-            </li>
-            <li>
-              <span class="home-contact-label">Research</span>
-              <a href="mailto:research@vcasse.org">research@vcasse.org</a>
-            </li>
-          </ul>
-          <span class="home-contact-location">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-            Vancouver, BC, Canada
-          </span>
-        </div>
-        <div class="home-contact-cta">
-          <h3>Send us a message</h3>
-          <p>Have a longer note, a research collaboration, or a media request? Use our full contact form for a written reply within two business days.</p>
-          <a class="btn btn-primary" href="contact.html">Open contact form <span aria-hidden="true">→</span></a>
-        </div>
+      <div class="home-contact-info">
+        <h2 id="home-contact-heading">Get in touch</h2>
+        <p>Most messages get a reply in a couple of business days. Press queries, faster.</p>
+        <ul class="home-contact-emails">
+          <li>
+            <span class="home-contact-label">General</span>
+            <a href="mailto:info@vcasse.org">info@vcasse.org</a>
+          </li>
+          <li>
+            <span class="home-contact-label">Press</span>
+            <a href="mailto:media@vcasse.org">media@vcasse.org</a>
+          </li>
+          <li>
+            <span class="home-contact-label">Research</span>
+            <a href="mailto:research@vcasse.org">research@vcasse.org</a>
+          </li>
+        </ul>
+        <p class="home-contact-aside">If you'd rather use a form, <a href="contact.html">there's one over here</a>.</p>
       </div>
     </div>
   </section>
@@ -242,11 +212,11 @@
   <!-- CONTRIBUTE CTA -->
   <section class="contribute-cta" id="contribute">
     <div class="container fade-in">
-      <h2 class="cta-title">Contribute to the Future of Responsible AI.</h2>
-      <p class="cta-description">We serve the general public, youth and students, tech companies and developers, and policymakers. If AI affects your life, we're here for you.</p>
+      <h2 class="cta-title">Want to be involved?</h2>
+      <p class="cta-description">We work with researchers, public servants, journalists, and people who just want to follow what's happening in the city. Say hi.</p>
       <div class="cta-buttons">
-        <a href="contact.html" class="btn btn-white btn-uppercase"><span class="menu-label">Get in Touch</span></a>
-        <a href="about.html" class="btn btn-outlined btn-uppercase"><span class="menu-label">About Us</span></a>
+        <a href="contact.html" class="btn btn-white"><span class="menu-label">Say hi</span></a>
+        <a href="about.html" class="btn btn-outlined"><span class="menu-label">About us</span></a>
       </div>
     </div>
   </section>

--- a/dev/js/publications-page.js
+++ b/dev/js/publications-page.js
@@ -11,8 +11,15 @@
     const grid = document.getElementById('publicationsGrid');
     if (!grid || typeof window.getPublications !== 'function') return;
 
-    const posts = window.getPublications();
-    updateHeroStats(posts);
+    const lockedPillar = grid.dataset.pillar && grid.dataset.pillar !== 'all'
+      ? grid.dataset.pillar
+      : null;
+    const baseHref = grid.dataset.baseHref || '';
+    const allPosts = window.getPublications();
+    const posts = lockedPillar
+      ? allPosts.filter((p) => p.pillar === lockedPillar)
+      : allPosts;
+    updateHeroStats(lockedPillar ? posts : allPosts);
     const filterButtons = Array.from(document.querySelectorAll('[data-pub-filter]'));
     const tagSelect = document.getElementById('publicationsTag');
     const sortSelect = document.getElementById('publicationsSort');
@@ -153,10 +160,12 @@
       const dateText = formatDate(post.date);
       const tags = post.tags.map((t) => `<li>${escapeHtml(t)}</li>`).join('');
       const authors = (post.authors || []).join(', ');
+      const url = baseHref + post.url;
+      const cover = baseHref + post.cover;
 
       article.innerHTML = `
-        <a class="publication-card-cover" href="${post.url}" aria-label="Read ${escapeHtml(post.title)}">
-          <img src="${post.cover}" alt="" loading="lazy" decoding="async">
+        <a class="publication-card-cover" href="${url}" aria-label="Read ${escapeHtml(post.title)}">
+          <img src="${cover}" alt="" loading="lazy" decoding="async">
           <span class="publication-pill publication-pill--${post.pillar}">${pillarLabel}</span>
         </a>
         <div class="publication-card-body">
@@ -165,11 +174,11 @@
             <span aria-hidden="true">·</span>
             <span>${escapeHtml(post.readingTime)}</span>
           </div>
-          <h3><a href="${post.url}">${escapeHtml(post.title)}</a></h3>
+          <h3><a href="${url}">${escapeHtml(post.title)}</a></h3>
           <p>${escapeHtml(post.excerpt)}</p>
           ${authors ? `<p class="publication-card-authors">By ${escapeHtml(authors)}</p>` : ''}
           <ul class="publication-tags">${tags}</ul>
-          <a class="modern-card-link" href="${post.url}">Read publication <span aria-hidden="true">→</span></a>
+          <a class="modern-card-link" href="${url}">Read publication <span aria-hidden="true">→</span></a>
         </div>
       `;
       return article;

--- a/dev/js/publications-page.js
+++ b/dev/js/publications-page.js
@@ -166,10 +166,10 @@
       article.innerHTML = `
         <a class="publication-card-cover" href="${url}" aria-label="Read ${escapeHtml(post.title)}">
           <img src="${cover}" alt="" loading="lazy" decoding="async">
-          <span class="publication-pill publication-pill--${post.pillar}">${pillarLabel}</span>
         </a>
         <div class="publication-card-body">
           <div class="publication-card-meta">
+            <span class="publication-pill publication-pill--${post.pillar}">${pillarLabel}</span>
             <span>${dateText}</span>
             <span aria-hidden="true">·</span>
             <span>${escapeHtml(post.readingTime)}</span>
@@ -178,7 +178,7 @@
           <p>${escapeHtml(post.excerpt)}</p>
           ${authors ? `<p class="publication-card-authors">By ${escapeHtml(authors)}</p>` : ''}
           <ul class="publication-tags">${tags}</ul>
-          <a class="modern-card-link" href="${url}">Read publication <span aria-hidden="true">→</span></a>
+          <a class="modern-card-link" href="${url}">Read it <span aria-hidden="true">→</span></a>
         </div>
       `;
       return article;

--- a/dev/js/publications-related.js
+++ b/dev/js/publications-related.js
@@ -29,20 +29,17 @@ document.addEventListener('DOMContentLoaded', () => {
       card.innerHTML = `
         <a class="publication-card-cover" href="${url}" aria-label="Read ${escapeHtml(post.title)}">
           <img src="${cover}" alt="" loading="lazy" decoding="async">
-          <span class="publication-pill publication-pill--${post.pillar}">${PILLAR_LABELS[post.pillar] || post.pillar}</span>
         </a>
         <div class="publication-card-body">
           <div class="publication-card-meta">
+            <span class="publication-pill publication-pill--${post.pillar}">${PILLAR_LABELS[post.pillar] || post.pillar}</span>
             <span>${formatDate(post.date)}</span>
             <span aria-hidden="true">·</span>
             <span>${escapeHtml(post.readingTime)}</span>
           </div>
           <h3><a href="${url}">${escapeHtml(post.title)}</a></h3>
           <p>${escapeHtml(post.excerpt)}</p>
-          <ul class="publication-tags">
-            ${post.tags.map((tag) => `<li>${escapeHtml(tag)}</li>`).join('')}
-          </ul>
-          <a class="modern-card-link" href="${url}">Read publication <span aria-hidden="true">→</span></a>
+          <a class="modern-card-link" href="${url}">Read it <span aria-hidden="true">→</span></a>
         </div>
       `;
       container.appendChild(card);

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -42,27 +42,9 @@
   <section class="page-hero publications-hero">
     <div class="container">
       <div class="page-hero-content">
-        <div class="section-label">PUBLICATIONS</div>
-        <h1 class="page-hero-title">
-          Policy briefs,
-          <span class="italic-accent">research &amp; explainers</span>
-        </h1>
-        <p class="page-hero-description">VCASSE publishes practical research across Safety, Sustainability, and Ethics &mdash; written to inform Vancouver's policymakers, developers, and residents as AI reshapes public life.</p>
+        <h1 class="page-hero-title">Publications</h1>
+        <p class="page-hero-description">Briefs, notes, and explainers on what we're working on. Filter by topic or search by tag.</p>
       </div>
-      <aside class="publications-hero-visual" aria-hidden="true">
-        <div class="publications-hero-stat-card">
-          <div class="publications-hero-stat">
-            <span class="publications-hero-stat-num" id="publicationsHeroCount">6</span>
-            <span class="publications-hero-stat-label">publications</span>
-          </div>
-          <ul class="publications-hero-pillars">
-            <li><span class="publication-pill publication-pill--safety">Safety</span><span>2</span></li>
-            <li><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>2</span></li>
-            <li><span class="publication-pill publication-pill--ethics">Ethics</span><span>2</span></li>
-          </ul>
-          <p class="publications-hero-note">Updated continuously as our research program grows.</p>
-        </div>
-      </aside>
     </div>
   </section>
 
@@ -117,15 +99,15 @@
     <div class="container">
       <div class="newsletter-card">
         <div class="newsletter-content">
-          <p class="newsletter-kicker">Newsletter &middot; <span class="newsletter-soon">Coming soon</span></p>
+          <p class="newsletter-kicker"><span class="newsletter-soon">Coming soon</span></p>
           <h2 id="newsletter-heading">The VCASSE Briefing</h2>
-          <p class="newsletter-lede">A monthly dispatch with new publications, upcoming public panels, and plain-language notes on what Vancouver should know about AI policy, infrastructure, and ethics.</p>
+          <p class="newsletter-lede">A short monthly note on what we're publishing and what's happening in the city.</p>
         </div>
         <form class="newsletter-form" onsubmit="event.preventDefault();" aria-describedby="newsletter-soon-note">
           <label for="newsletter-email" class="visually-hidden">Email address</label>
           <input type="email" id="newsletter-email" placeholder="you@example.com" disabled aria-disabled="true">
           <button type="button" class="btn btn-primary" disabled aria-disabled="true">Notify me</button>
-          <p class="newsletter-note" id="newsletter-soon-note">Sign-ups open soon &mdash; we're still setting things up.</p>
+          <p class="newsletter-note" id="newsletter-soon-note">Sign-ups open soon. We're still setting things up.</p>
         </form>
       </div>
     </div>

--- a/dev/publications/ethics.html
+++ b/dev/publications/ethics.html
@@ -42,26 +42,10 @@
   <section class="page-hero publications-hero">
     <div class="container">
       <div class="page-hero-content">
-        <div class="section-label">Ethics &middot; Publications</div>
-        <h1 class="page-hero-title">
-          Ethics
-          <span class="italic-accent">research &amp; briefs</span>
-        </h1>
-        <p class="page-hero-description">Justice, governance, and participation &mdash; how AI decisions affecting Vancouver residents can be made transparently and with public input.</p>
         <p class="publications-hero-crumb"><a href="../publications.html">&larr; All publications</a></p>
+        <h1 class="page-hero-title">Ethics</h1>
+        <p class="page-hero-description">Who decides where AI is used, who gets to push back, and how those decisions get made in cities like ours.</p>
       </div>
-      <aside class="publications-hero-visual" aria-hidden="true">
-        <div class="publications-hero-stat-card">
-          <div class="publications-hero-stat">
-            <span class="publications-hero-stat-num" id="publicationsHeroCount">2</span>
-            <span class="publications-hero-stat-label">ethics publications</span>
-          </div>
-          <ul class="publications-hero-pillars">
-            <li><span class="publication-pill publication-pill--ethics">Ethics</span><span>—</span></li>
-          </ul>
-          <p class="publications-hero-note">New work added as our research program grows.</p>
-        </div>
-      </aside>
     </div>
   </section>
 

--- a/dev/publications/ethics.html
+++ b/dev/publications/ethics.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ethics Publications | VCASSE</title>
+  <meta name="description" content="VCASSE publications on AI ethics: governance, participation, and accountability for civic and municipal AI.">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
+</head>
+<body>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="page-hero publications-hero">
+    <div class="container">
+      <div class="page-hero-content">
+        <div class="section-label">Ethics &middot; Publications</div>
+        <h1 class="page-hero-title">
+          Ethics
+          <span class="italic-accent">research &amp; briefs</span>
+        </h1>
+        <p class="page-hero-description">Justice, governance, and participation &mdash; how AI decisions affecting Vancouver residents can be made transparently and with public input.</p>
+        <p class="publications-hero-crumb"><a href="../publications.html">&larr; All publications</a></p>
+      </div>
+      <aside class="publications-hero-visual" aria-hidden="true">
+        <div class="publications-hero-stat-card">
+          <div class="publications-hero-stat">
+            <span class="publications-hero-stat-num" id="publicationsHeroCount">2</span>
+            <span class="publications-hero-stat-label">ethics publications</span>
+          </div>
+          <ul class="publications-hero-pillars">
+            <li><span class="publication-pill publication-pill--ethics">Ethics</span><span>—</span></li>
+          </ul>
+          <p class="publications-hero-note">New work added as our research program grows.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="publications-toolbar-section">
+    <div class="container">
+      <div class="publications-toolbar" role="region" aria-label="Publication filters">
+        <div class="publications-toolbar-row">
+          <div class="publications-search">
+            <svg class="publications-search-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 2a8 8 0 1 0 5.3 14.06l4.33 4.33 1.42-1.42-4.33-4.33A8 8 0 0 0 10 2zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12z" fill="currentColor"/></svg>
+            <input type="search" id="publicationsSearch" placeholder="Search title, tag, or author" aria-label="Search ethics publications">
+          </div>
+        </div>
+        <div class="publications-toolbar-row publications-toolbar-row--dense">
+          <div class="publications-select-group">
+            <label for="publicationsTag">Tag</label>
+            <select id="publicationsTag">
+              <option value="all">All tags</option>
+            </select>
+          </div>
+          <div class="publications-select-group">
+            <label for="publicationsSort">Sort</label>
+            <select id="publicationsSort">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="az">A &ndash; Z</option>
+            </select>
+          </div>
+          <p class="publications-count" id="publicationsCount" aria-live="polite">Showing all ethics publications</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-section publications-index">
+    <div class="container">
+      <div class="publications-grid" id="publicationsGrid" data-pillar="ethics" data-base-href="../" aria-live="polite"></div>
+      <div class="publications-empty" id="publicationsEmpty" hidden>
+        <h3>No ethics publications match those filters yet.</h3>
+        <p>Clear the search or change the tag filter.</p>
+        <button type="button" class="btn btn-secondary" id="publicationsReset">Reset filters</button>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+          <div class="footer-social">
+            <a href="#" aria-label="Share"><svg viewBox="0 0 24 24"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg></a>
+            <a href="#" aria-label="Email"><svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg></a>
+          </div>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-page.js"></script>
+  <script src="../js/main.js"></script>
+</body>
+</html>

--- a/dev/publications/safety.html
+++ b/dev/publications/safety.html
@@ -42,26 +42,10 @@
   <section class="page-hero publications-hero">
     <div class="container">
       <div class="page-hero-content">
-        <div class="section-label">Safety &middot; Publications</div>
-        <h1 class="page-hero-title">
-          Safety
-          <span class="italic-accent">research &amp; briefs</span>
-        </h1>
-        <p class="page-hero-description">Practical work on AI safety for public-interest teams &mdash; evaluations, incident response, and risk-aware deployment grounded in Vancouver's civic context.</p>
         <p class="publications-hero-crumb"><a href="../publications.html">&larr; All publications</a></p>
+        <h1 class="page-hero-title">Safety</h1>
+        <p class="page-hero-description">How AI systems break, how to catch it before they ship, and what to do when something goes wrong in production.</p>
       </div>
-      <aside class="publications-hero-visual" aria-hidden="true">
-        <div class="publications-hero-stat-card">
-          <div class="publications-hero-stat">
-            <span class="publications-hero-stat-num" id="publicationsHeroCount">2</span>
-            <span class="publications-hero-stat-label">safety publications</span>
-          </div>
-          <ul class="publications-hero-pillars">
-            <li><span class="publication-pill publication-pill--safety">Safety</span><span>—</span></li>
-          </ul>
-          <p class="publications-hero-note">New work added as our research program grows.</p>
-        </div>
-      </aside>
     </div>
   </section>
 

--- a/dev/publications/safety.html
+++ b/dev/publications/safety.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Safety Publications | VCASSE</title>
+  <meta name="description" content="VCASSE publications on AI safety: evaluations, incident response, and risk-aware deployment for public-interest teams.">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
+</head>
+<body>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="page-hero publications-hero">
+    <div class="container">
+      <div class="page-hero-content">
+        <div class="section-label">Safety &middot; Publications</div>
+        <h1 class="page-hero-title">
+          Safety
+          <span class="italic-accent">research &amp; briefs</span>
+        </h1>
+        <p class="page-hero-description">Practical work on AI safety for public-interest teams &mdash; evaluations, incident response, and risk-aware deployment grounded in Vancouver's civic context.</p>
+        <p class="publications-hero-crumb"><a href="../publications.html">&larr; All publications</a></p>
+      </div>
+      <aside class="publications-hero-visual" aria-hidden="true">
+        <div class="publications-hero-stat-card">
+          <div class="publications-hero-stat">
+            <span class="publications-hero-stat-num" id="publicationsHeroCount">2</span>
+            <span class="publications-hero-stat-label">safety publications</span>
+          </div>
+          <ul class="publications-hero-pillars">
+            <li><span class="publication-pill publication-pill--safety">Safety</span><span>—</span></li>
+          </ul>
+          <p class="publications-hero-note">New work added as our research program grows.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="publications-toolbar-section">
+    <div class="container">
+      <div class="publications-toolbar" role="region" aria-label="Publication filters">
+        <div class="publications-toolbar-row">
+          <div class="publications-search">
+            <svg class="publications-search-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 2a8 8 0 1 0 5.3 14.06l4.33 4.33 1.42-1.42-4.33-4.33A8 8 0 0 0 10 2zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12z" fill="currentColor"/></svg>
+            <input type="search" id="publicationsSearch" placeholder="Search title, tag, or author" aria-label="Search safety publications">
+          </div>
+        </div>
+        <div class="publications-toolbar-row publications-toolbar-row--dense">
+          <div class="publications-select-group">
+            <label for="publicationsTag">Tag</label>
+            <select id="publicationsTag">
+              <option value="all">All tags</option>
+            </select>
+          </div>
+          <div class="publications-select-group">
+            <label for="publicationsSort">Sort</label>
+            <select id="publicationsSort">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="az">A &ndash; Z</option>
+            </select>
+          </div>
+          <p class="publications-count" id="publicationsCount" aria-live="polite">Showing all safety publications</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-section publications-index">
+    <div class="container">
+      <div class="publications-grid" id="publicationsGrid" data-pillar="safety" data-base-href="../" aria-live="polite"></div>
+      <div class="publications-empty" id="publicationsEmpty" hidden>
+        <h3>No safety publications match those filters yet.</h3>
+        <p>Clear the search or change the tag filter.</p>
+        <button type="button" class="btn btn-secondary" id="publicationsReset">Reset filters</button>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+          <div class="footer-social">
+            <a href="#" aria-label="Share"><svg viewBox="0 0 24 24"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg></a>
+            <a href="#" aria-label="Email"><svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg></a>
+          </div>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-page.js"></script>
+  <script src="../js/main.js"></script>
+</body>
+</html>

--- a/dev/publications/sustainability.html
+++ b/dev/publications/sustainability.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sustainability Publications | VCASSE</title>
+  <meta name="description" content="VCASSE publications on AI sustainability: energy reporting, procurement, and lifecycle impact in a changing climate.">
+  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="icon" type="image/svg+xml" href="../img/logo.svg">
+</head>
+<body>
+  <nav class="navbar">
+    <div class="container">
+      <a href="../index.html" class="nav-logo nav-logo-mark">
+        <img src="../img/logo.svg" alt="VCASSE" width="28" height="28">
+        VCASSE
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="../index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="../sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="../ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
+        <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="page-hero publications-hero">
+    <div class="container">
+      <div class="page-hero-content">
+        <div class="section-label">Sustainability &middot; Publications</div>
+        <h1 class="page-hero-title">
+          Sustainability
+          <span class="italic-accent">research &amp; briefs</span>
+        </h1>
+        <p class="page-hero-description">Energy, data, and lifecycle impact of AI systems &mdash; written for procurement teams, infrastructure planners, and reporting standards.</p>
+        <p class="publications-hero-crumb"><a href="../publications.html">&larr; All publications</a></p>
+      </div>
+      <aside class="publications-hero-visual" aria-hidden="true">
+        <div class="publications-hero-stat-card">
+          <div class="publications-hero-stat">
+            <span class="publications-hero-stat-num" id="publicationsHeroCount">2</span>
+            <span class="publications-hero-stat-label">sustainability publications</span>
+          </div>
+          <ul class="publications-hero-pillars">
+            <li><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>—</span></li>
+          </ul>
+          <p class="publications-hero-note">New work added as our research program grows.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="publications-toolbar-section">
+    <div class="container">
+      <div class="publications-toolbar" role="region" aria-label="Publication filters">
+        <div class="publications-toolbar-row">
+          <div class="publications-search">
+            <svg class="publications-search-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 2a8 8 0 1 0 5.3 14.06l4.33 4.33 1.42-1.42-4.33-4.33A8 8 0 0 0 10 2zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12z" fill="currentColor"/></svg>
+            <input type="search" id="publicationsSearch" placeholder="Search title, tag, or author" aria-label="Search sustainability publications">
+          </div>
+        </div>
+        <div class="publications-toolbar-row publications-toolbar-row--dense">
+          <div class="publications-select-group">
+            <label for="publicationsTag">Tag</label>
+            <select id="publicationsTag">
+              <option value="all">All tags</option>
+            </select>
+          </div>
+          <div class="publications-select-group">
+            <label for="publicationsSort">Sort</label>
+            <select id="publicationsSort">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="az">A &ndash; Z</option>
+            </select>
+          </div>
+          <p class="publications-count" id="publicationsCount" aria-live="polite">Showing all sustainability publications</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-section publications-index">
+    <div class="container">
+      <div class="publications-grid" id="publicationsGrid" data-pillar="sustainability" data-base-href="../" aria-live="polite"></div>
+      <div class="publications-empty" id="publicationsEmpty" hidden>
+        <h3>No sustainability publications match those filters yet.</h3>
+        <p>Clear the search or change the tag filter.</p>
+        <button type="button" class="btn btn-secondary" id="publicationsReset">Reset filters</button>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+          <div class="footer-social">
+            <a href="#" aria-label="Share"><svg viewBox="0 0 24 24"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg></a>
+            <a href="#" aria-label="Email"><svg viewBox="0 0 24 24"><path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/></svg></a>
+          </div>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="../safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="../sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="../ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
+            <li><a href="../about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
+            <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>
+            <li><a href="../terms.html"><span class="menu-label">Terms of Service</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <div class="footer-location">
+          <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+          Vancouver, BC, Canada
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/publications-data.js"></script>
+  <script src="../js/publications-page.js"></script>
+  <script src="../js/main.js"></script>
+</body>
+</html>

--- a/dev/publications/sustainability.html
+++ b/dev/publications/sustainability.html
@@ -42,26 +42,10 @@
   <section class="page-hero publications-hero">
     <div class="container">
       <div class="page-hero-content">
-        <div class="section-label">Sustainability &middot; Publications</div>
-        <h1 class="page-hero-title">
-          Sustainability
-          <span class="italic-accent">research &amp; briefs</span>
-        </h1>
-        <p class="page-hero-description">Energy, data, and lifecycle impact of AI systems &mdash; written for procurement teams, infrastructure planners, and reporting standards.</p>
         <p class="publications-hero-crumb"><a href="../publications.html">&larr; All publications</a></p>
+        <h1 class="page-hero-title">Sustainability</h1>
+        <p class="page-hero-description">The energy, water, and hardware costs of running AI at scale, and what honest reporting looks like.</p>
       </div>
-      <aside class="publications-hero-visual" aria-hidden="true">
-        <div class="publications-hero-stat-card">
-          <div class="publications-hero-stat">
-            <span class="publications-hero-stat-num" id="publicationsHeroCount">2</span>
-            <span class="publications-hero-stat-label">sustainability publications</span>
-          </div>
-          <ul class="publications-hero-pillars">
-            <li><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>—</span></li>
-          </ul>
-          <p class="publications-hero-note">New work added as our research program grows.</p>
-        </div>
-      </aside>
     </div>
   </section>
 

--- a/dev/safety.html
+++ b/dev/safety.html
@@ -109,6 +109,9 @@
         <h2 class="home-section-title">Latest safety publications</h2>
       </header>
       <div class="publication-cards-grid" data-related-publications data-pillar="safety" data-limit="2"></div>
+      <div class="home-publications-cta">
+        <a class="btn btn-secondary" href="publications/safety.html">View all safety publications <span aria-hidden="true">→</span></a>
+      </div>
     </div>
   </section>
 

--- a/dev/sustainability.html
+++ b/dev/sustainability.html
@@ -109,6 +109,9 @@
         <h2 class="home-section-title">Latest sustainability publications</h2>
       </header>
       <div class="publication-cards-grid" data-related-publications data-pillar="sustainability" data-limit="2"></div>
+      <div class="home-publications-cta">
+        <a class="btn btn-secondary" href="publications/sustainability.html">View all sustainability publications <span aria-hidden="true">→</span></a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
- Promote publications above pillars on home, with featured lead card and 3-up grid
- Add home contact strip (info + form CTA) above the contribute section
- New pillar publication pages at publications/{safety,sustainability,ethics}.html
  filtered to a single pillar via data-pillar on the grid; data-base-href resolves
  asset paths from the subdirectory
- Bigger mobile submenu so Safety / Sustainability / Ethics are legible tap targets
- Modernize contact.html: 2x2 contact-detail grid, refreshed hero kicker
- Tidy publication-card hover; add featured/contact/breadcrumb styles

https://claude.ai/code/session_014mkZYWriPePBEX3njZ568Q