### PR TITLE
Improve mobile responsiveness for legal (privacy/terms) pages

### DIFF
--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -1593,12 +1593,16 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* ─────────────── LEGAL PAGES ─────────────── */
 
-.legal-content { max-width: 800px; margin: 0 auto; padding: 60px 48px 100px; }
+.legal-content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 60px 48px 100px;
+}
 
 .legal-content h1 {
   font-family: var(--font-sans);
   font-weight: 800;
-  font-size: 48px;
+  font-size: clamp(2.25rem, 4.2vw, 3rem);
   color: var(--text-dark);
   letter-spacing: -1.5px;
   margin-bottom: 8px;
@@ -1615,9 +1619,17 @@ img { max-width: 100%; height: auto; display: block; }
   letter-spacing: -0.3px;
 }
 
-.legal-content p { font-size: 15px; line-height: 1.8; color: var(--text-body); margin-bottom: 16px; }
+.legal-content p,
+.legal-content li {
+  font-size: clamp(0.98rem, 1.35vw, 1.05rem);
+  line-height: 1.8;
+  color: var(--text-body);
+  margin-bottom: 16px;
+  overflow-wrap: anywhere;
+}
+
 .legal-content ul { padding-left: 24px; margin-bottom: 20px; }
-.legal-content li { font-size: 15px; line-height: 1.8; color: var(--text-body); margin-bottom: 8px; }
+.legal-content li { margin-bottom: 8px; }
 
 /* ─────────────── ANIMATIONS ─────────────── */
 
@@ -1988,14 +2000,41 @@ noscript + * .fade-in,
   .page-hero-visual { justify-content: flex-start; }
   .cta-buttons { flex-direction: column; align-items: stretch; }
   .contact-grid { grid-template-columns: 1fr; }
-  .legal-content { padding: 40px 0 60px; }
-  .legal-content h2 { font-size: 20px; }
+  .legal-content {
+    padding: 36px 20px 60px;
+  }
+  .legal-content h1 {
+    letter-spacing: -0.04em;
+  }
+  .legal-content h2 {
+    font-size: 20px;
+    margin-top: 32px;
+  }
+  .legal-content ul {
+    padding-left: 20px;
+  }
   .form-row { grid-template-columns: 1fr; }
   .about-page { padding-bottom: 60px; }
   .events-calendar-row { grid-template-columns: 1fr; gap: 28px; }
   .events-hero-stack { max-width: none; align-items: stretch; }
   .events-hero-caption { text-align: left; max-width: none; }
   .events-hero-figure { align-items: stretch; }
+}
+
+@media (max-width: 480px) {
+  .legal-content {
+    padding: 30px 16px 50px;
+  }
+
+  .legal-content h2 {
+    font-size: 1.2rem;
+    margin: 28px 0 14px;
+  }
+
+  .legal-content p,
+  .legal-content li {
+    line-height: 1.75;
+  }
 }
 
 /* ─────────────── MOBILE DRAWER — Editorial Index + Circular Reveal ─────────────── */


### PR DESCRIPTION
### Motivation
- Legal pages (privacy/terms) needed improved typography and spacing on small viewports so content doesn't hug the edges or produce long unwrapped lines.

### Description
- Updated `dev/css/styles.css` to make `.legal-content h1` scale with `clamp()` for responsive title sizing.
- Switched `.legal-content p` and `.legal-content li` to a `clamp()`-based font size and added `overflow-wrap: anywhere;` to prevent long-line overflow and improve wrapping.
- Restored and tuned horizontal padding for `.legal-content` at mobile breakpoints (`@media (max-width: 768px)` and added `@media (max-width: 480px)`) and tightened heading/list spacing for better vertical rhythm.
- Adjusted `ul` padding and some heading letter-spacing to improve readability on narrow screens.

### Testing
- Ran `git diff --check` and there were no style or whitespace errors.
- Checked working tree status with `git status --short` to confirm the modified file is present.
- No browser screenshot tests could be run in this environment, so visual verification should be performed in a device/emulation test after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed342b0f4083209d292eeec973a24c)