### PR TITLE
Modernize navbar and research dropdown visuals

### DIFF
--- a/dev/about.html
+++ b/dev/about.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html" class="active"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -145,7 +145,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/about.html
+++ b/dev/about.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/contact.html
+++ b/dev/contact.html
@@ -24,7 +24,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/contact.html
+++ b/dev/contact.html
@@ -33,10 +33,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html" class="active"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -204,7 +204,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -98,8 +98,11 @@ img { max-width: 100%; height: auto; display: block; }
 /* ─────────────── NAVIGATION ─────────────── */
 
 .navbar {
-  position: sticky;
+  position: fixed;
   top: 10px;
+  left: 0;
+  right: 0;
+  width: 100%;
   z-index: 1000;
   background: transparent;
   border-bottom: none;

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -60,11 +60,11 @@
   --font-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
   --max-width: 1200px;
   --nav-height: 74px;
-  --nav-surface: rgba(4, 12, 26, 0.9);
-  --nav-surface-scrolled: rgba(3, 10, 20, 0.95);
-  --nav-ring: rgba(127, 205, 255, 0.42);
-  --nav-item-hover: rgba(255, 255, 255, 0.12);
-  --nav-item-active: rgba(255, 255, 255, 0.2);
+  --nav-surface: rgba(8, 42, 77, 0.9);
+  --nav-surface-scrolled: rgba(5, 26, 46, 0.95);
+  --nav-ring: rgba(108, 180, 228, 0.45);
+  --nav-item-hover: rgba(108, 180, 228, 0.18);
+  --nav-item-active: rgba(108, 180, 228, 0.26);
   --dropdown-shadow: 0 24px 56px rgba(2, 8, 20, 0.45);
 }
 
@@ -125,7 +125,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-radius: 22px;
   background: var(--nav-surface);
   border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 14px 40px rgba(2, 10, 28, 0.35), inset 0 1px 0 rgba(255,255,255,0.18);
+  box-shadow: 0 14px 40px rgba(5, 26, 46, 0.35), inset 0 1px 0 rgba(255,255,255,0.18);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   transition: background 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
@@ -134,7 +134,7 @@ img { max-width: 100%; height: auto; display: block; }
 .navbar.is-scrolled .container {
   background: var(--nav-surface-scrolled);
   border-color: rgba(255, 255, 255, 0.2);
-  box-shadow: 0 16px 44px rgba(2, 10, 28, 0.45), inset 0 1px 0 rgba(255,255,255,0.2);
+  box-shadow: 0 16px 44px rgba(5, 26, 46, 0.45), inset 0 1px 0 rgba(255,255,255,0.2);
 }
 
 .navbar .nav-logo-mark {
@@ -232,7 +232,7 @@ img { max-width: 100%; height: auto; display: block; }
   display: block;
   width: 22px;
   height: 2px;
-  background: var(--text-dark);
+  background: rgba(240, 247, 255, 0.95);
   border-radius: 2px;
   transition: transform 0.4s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.3s ease, background 0.3s ease;
   position: absolute;
@@ -306,6 +306,15 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 @media (min-width: 769px) {
+  .nav-links > li.nav-dropdown::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    height: 14px;
+  }
+
   .nav-dropdown-trigger {
     position: relative;
   }
@@ -342,12 +351,12 @@ img { max-width: 100%; height: auto; display: block; }
 @media (min-width: 769px) {
   .nav-dropdown-menu {
     position: absolute;
-    top: calc(100% + 10px);
+    top: calc(100% + 4px);
     left: 50%;
     transform: translateX(-50%) translateY(8px) scale(0.98);
     min-width: 240px;
     padding: 10px;
-    background: linear-gradient(180deg, rgba(7, 21, 40, 0.98), rgba(5, 16, 32, 0.98));
+    background: linear-gradient(180deg, rgba(8, 42, 77, 0.98), rgba(5, 26, 46, 0.98));
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 14px;
     box-shadow: var(--dropdown-shadow);
@@ -379,7 +388,7 @@ img { max-width: 100%; height: auto; display: block; }
     height: 12px;
     border-left: 1px solid rgba(255, 255, 255, 0.12);
     border-top: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(7, 21, 40, 0.97);
+    background: rgba(8, 42, 77, 0.97);
     transform: translateX(-50%) rotate(45deg);
   }
 }
@@ -432,8 +441,8 @@ img { max-width: 100%; height: auto; display: block; }
   justify-content: center;
   padding: 11px 18px;
   border-radius: 999px;
-  border: 1px solid rgba(127, 205, 255, 0.35);
-  background: linear-gradient(135deg, rgba(127,205,255,0.24), rgba(101,169,255,0.36));
+  border: 1px solid rgba(108, 180, 228, 0.5);
+  background: linear-gradient(135deg, rgba(13,79,139,0.94), rgba(26,109,181,0.92));
   color: var(--white);
   font-size: 13px;
   font-weight: 700;
@@ -443,13 +452,13 @@ img { max-width: 100%; height: auto; display: block; }
 
 .nav-cta:hover {
   transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(101, 169, 255, 0.35);
-  filter: brightness(1.05);
+  box-shadow: 0 10px 24px rgba(13, 79, 139, 0.4);
+  filter: brightness(1.08);
 }
 
 .nav-cta.active {
-  background: linear-gradient(135deg, rgba(127,205,255,0.36), rgba(127,205,255,0.52));
-  border-color: rgba(127, 205, 255, 0.55);
+  background: linear-gradient(135deg, rgba(26,109,181,0.96), rgba(13,79,139,0.96));
+  border-color: rgba(108, 180, 228, 0.62);
 }
 
 @media (max-width: 900px) {

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -60,6 +60,12 @@
   --font-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
   --max-width: 1200px;
   --nav-height: 64px;
+  --nav-surface: rgba(255, 255, 255, 0.84);
+  --nav-surface-scrolled: rgba(255, 255, 255, 0.92);
+  --nav-ring: rgba(13, 79, 139, 0.18);
+  --nav-item-hover: rgba(13, 79, 139, 0.08);
+  --nav-item-active: rgba(13, 79, 139, 0.14);
+  --dropdown-shadow: 0 18px 44px rgba(7, 24, 48, 0.18);
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
@@ -95,13 +101,20 @@ img { max-width: 100%; height: auto; display: block; }
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: rgba(255, 255, 255, 0.94);
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--nav-surface);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
   height: var(--nav-height);
   display: flex;
   align-items: center;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
+  transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.navbar.is-scrolled {
+  background: var(--nav-surface-scrolled);
+  border-bottom-color: rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
 }
 
 .navbar .container {
@@ -132,35 +145,38 @@ img { max-width: 100%; height: auto; display: block; }
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 32px;
+  gap: 8px;
   list-style: none;
+  padding: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .nav-links a {
   font-size: 14px;
   font-weight: 500;
   color: var(--text-body);
-  padding: 4px 0;
+  padding: 8px 14px;
+  border-radius: 999px;
   position: relative;
-  transition: color 0.2s ease;
+  transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease;
 }
 
-.nav-links a:hover { color: var(--primary); }
+.nav-links a:hover {
+  color: var(--primary-dark);
+  background: var(--nav-item-hover);
+}
 
 .nav-links a.active {
   color: var(--text-dark);
   font-weight: 600;
+  background: var(--nav-item-active);
 }
 
 .nav-links a.active::after {
-  content: '';
-  position: absolute;
-  bottom: -4px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: var(--primary);
-  border-radius: 1px;
+  display: none;
 }
 
 .nav-logo-mark {
@@ -260,15 +276,17 @@ img { max-width: 100%; height: auto; display: block; }
   background: none;
   border: none;
   cursor: pointer;
-  padding: 8px 0;
+  padding: 8px 14px;
+  border-radius: 999px;
   line-height: 1.2;
-  transition: color 0.2s ease;
+  transition: color 0.2s ease, background 0.2s ease;
 }
 
 .nav-dropdown-trigger:hover,
 .nav-dropdown:focus-within .nav-dropdown-trigger,
 .nav-dropdown.is-open .nav-dropdown-trigger {
   color: var(--primary-dark);
+  background: var(--nav-item-hover);
 }
 
 .nav-dropdown--active .nav-dropdown-trigger {
@@ -282,28 +300,22 @@ img { max-width: 100%; height: auto; display: block; }
   }
 
   .nav-dropdown--active .nav-dropdown-trigger::after {
-    content: '';
-    position: absolute;
-    bottom: -4px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: var(--primary);
-    border-radius: 1px;
+    display: none;
   }
 }
 
-/* Plus icon → rotates 45° when open (reads as “close section” / ×) */
+/* Chevron rotates on open for clear dropdown affordance */
 .nav-chevron {
   flex-shrink: 0;
-  opacity: 0.55;
-  transition: transform 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+  opacity: 0.7;
+  transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.2s ease;
   transform-origin: center;
 }
 
 .nav-dropdown.is-open .nav-chevron,
 .nav-dropdown:hover .nav-chevron {
-  transform: rotate(45deg);
+  transform: rotate(180deg);
+  opacity: 1;
 }
 
 .nav-dropdown-menu li {
@@ -319,19 +331,21 @@ img { max-width: 100%; height: auto; display: block; }
 @media (min-width: 769px) {
   .nav-dropdown-menu {
     position: absolute;
-    top: calc(100% + 4px);
+    top: calc(100% + 10px);
     left: 50%;
-    transform: translateX(-50%) translateY(4px);
-    min-width: 220px;
-    padding: 8px;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+    transform: translateX(-50%) translateY(8px) scale(0.98);
+    min-width: 240px;
+    padding: 10px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(246,250,255,0.96));
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 14px;
+    box-shadow: var(--dropdown-shadow);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
-    transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
+    transition: opacity 0.2s ease, transform 0.24s cubic-bezier(0.22, 1, 0.36, 1), visibility 0.2s;
     z-index: 1200;
   }
 
@@ -341,27 +355,42 @@ img { max-width: 100%; height: auto; display: block; }
     opacity: 1;
     visibility: visible;
     pointer-events: auto;
-    transform: translateX(-50%) translateY(0);
+    transform: translateX(-50%) translateY(0) scale(1);
+    animation: navMenuIn 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .nav-dropdown-menu::before {
+    content: '';
+    position: absolute;
+    top: -6px;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    border-left: 1px solid rgba(15, 23, 42, 0.1);
+    border-top: 1px solid rgba(15, 23, 42, 0.1);
+    background: rgba(255, 255, 255, 0.96);
+    transform: translateX(-50%) rotate(45deg);
   }
 }
 
 .nav-dropdown-menu a {
   display: block;
-  padding: 10px 14px;
-  border-radius: 8px;
+  padding: 11px 14px;
+  border-radius: 10px;
   font-size: 14px;
   font-weight: 600;
   color: var(--slate-professional);
-  transition: background 0.15s ease, color 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
 
 .nav-dropdown-menu a:hover {
-  background: var(--bg-page);
+  background: rgba(13, 79, 139, 0.1);
   color: var(--ink-strong);
+  transform: translateX(2px);
 }
 
 .nav-dropdown-menu a.active {
-  background: #ecfdf5;
+  background: linear-gradient(90deg, rgba(13,79,139,0.16), rgba(13,79,139,0.1));
   color: var(--primary-dark);
   font-weight: 600;
 }
@@ -372,7 +401,25 @@ img { max-width: 100%; height: auto; display: block; }
 
 @media (min-width: 769px) {
   .nav-links > li > a:not(.nav-dropdown-trigger) {
-    padding: 8px 0;
+    padding: 8px 14px;
+  }
+}
+
+.nav-links a:focus-visible,
+.nav-dropdown-trigger:focus-visible,
+.nav-dropdown-menu a:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--nav-ring);
+}
+
+@keyframes navMenuIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(10px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
   }
 }
 
@@ -2084,6 +2131,9 @@ noscript + * .fade-in,
     position: fixed; inset: 0;
     width: 100%; max-width: none;
     margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
     padding:
       calc(env(safe-area-inset-top, 0px) + var(--nav-height) + 16px)
       20px

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -59,13 +59,13 @@
   --font-display: 'IBM Plex Sans', var(--font-sans);
   --font-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
   --max-width: 1200px;
-  --nav-height: 64px;
-  --nav-surface: rgba(255, 255, 255, 0.84);
-  --nav-surface-scrolled: rgba(255, 255, 255, 0.92);
-  --nav-ring: rgba(13, 79, 139, 0.18);
-  --nav-item-hover: rgba(13, 79, 139, 0.08);
-  --nav-item-active: rgba(13, 79, 139, 0.14);
-  --dropdown-shadow: 0 18px 44px rgba(7, 24, 48, 0.18);
+  --nav-height: 74px;
+  --nav-surface: rgba(4, 12, 26, 0.9);
+  --nav-surface-scrolled: rgba(3, 10, 20, 0.95);
+  --nav-ring: rgba(127, 205, 255, 0.42);
+  --nav-item-hover: rgba(255, 255, 255, 0.12);
+  --nav-item-active: rgba(255, 255, 255, 0.2);
+  --dropdown-shadow: 0 24px 56px rgba(2, 8, 20, 0.45);
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
@@ -99,22 +99,18 @@ img { max-width: 100%; height: auto; display: block; }
 
 .navbar {
   position: sticky;
-  top: 0;
+  top: 10px;
   z-index: 1000;
-  background: var(--nav-surface);
-  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  background: transparent;
+  border-bottom: none;
   height: var(--nav-height);
   display: flex;
   align-items: center;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  transition: top 0.25s ease;
 }
 
 .navbar.is-scrolled {
-  background: var(--nav-surface-scrolled);
-  border-bottom-color: rgba(15, 23, 42, 0.08);
-  box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
+  top: 6px;
 }
 
 .navbar .container {
@@ -123,8 +119,22 @@ img { max-width: 100%; height: auto; display: block; }
   justify-content: space-between;
   width: 100%;
   min-height: var(--nav-height);
-  gap: 12px;
+  gap: 16px;
   position: relative;
+  padding: 0 18px;
+  border-radius: 22px;
+  background: var(--nav-surface);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 14px 40px rgba(2, 10, 28, 0.35), inset 0 1px 0 rgba(255,255,255,0.18);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: background 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.navbar.is-scrolled .container {
+  background: var(--nav-surface-scrolled);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 16px 44px rgba(2, 10, 28, 0.45), inset 0 1px 0 rgba(255,255,255,0.2);
 }
 
 .navbar .nav-logo-mark {
@@ -139,25 +149,25 @@ img { max-width: 100%; height: auto; display: block; }
   font-size: 13px;
   letter-spacing: 0.1px;
   line-height: 1;
-  color: var(--ink-strong);
+  color: var(--white);
 }
 
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   list-style: none;
-  padding: 6px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 
 .nav-links a {
   font-size: 14px;
   font-weight: 500;
-  color: var(--text-body);
+  color: rgba(240, 247, 255, 0.86);
   padding: 8px 14px;
   border-radius: 999px;
   position: relative;
@@ -165,12 +175,12 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 .nav-links a:hover {
-  color: var(--primary-dark);
+  color: var(--white);
   background: var(--nav-item-hover);
 }
 
 .nav-links a.active {
-  color: var(--text-dark);
+  color: var(--white);
   font-weight: 600;
   background: var(--nav-item-active);
 }
@@ -273,6 +283,7 @@ img { max-width: 100%; height: auto; display: block; }
   font-size: 14px;
   font-weight: 500;
   color: var(--text-body);
+  color: rgba(240, 247, 255, 0.86);
   background: none;
   border: none;
   cursor: pointer;
@@ -285,12 +296,12 @@ img { max-width: 100%; height: auto; display: block; }
 .nav-dropdown-trigger:hover,
 .nav-dropdown:focus-within .nav-dropdown-trigger,
 .nav-dropdown.is-open .nav-dropdown-trigger {
-  color: var(--primary-dark);
+  color: var(--white);
   background: var(--nav-item-hover);
 }
 
 .nav-dropdown--active .nav-dropdown-trigger {
-  color: var(--text-dark);
+  color: var(--white);
   font-weight: 600;
 }
 
@@ -336,8 +347,8 @@ img { max-width: 100%; height: auto; display: block; }
     transform: translateX(-50%) translateY(8px) scale(0.98);
     min-width: 240px;
     padding: 10px;
-    background: linear-gradient(180deg, rgba(255,255,255,0.98), rgba(246,250,255,0.96));
-    border: 1px solid rgba(15, 23, 42, 0.1);
+    background: linear-gradient(180deg, rgba(7, 21, 40, 0.98), rgba(5, 16, 32, 0.98));
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 14px;
     box-shadow: var(--dropdown-shadow);
     backdrop-filter: blur(12px);
@@ -366,9 +377,9 @@ img { max-width: 100%; height: auto; display: block; }
     left: 50%;
     width: 12px;
     height: 12px;
-    border-left: 1px solid rgba(15, 23, 42, 0.1);
-    border-top: 1px solid rgba(15, 23, 42, 0.1);
-    background: rgba(255, 255, 255, 0.96);
+    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(7, 21, 40, 0.97);
     transform: translateX(-50%) rotate(45deg);
   }
 }
@@ -379,19 +390,19 @@ img { max-width: 100%; height: auto; display: block; }
   border-radius: 10px;
   font-size: 14px;
   font-weight: 600;
-  color: var(--slate-professional);
+  color: rgba(232, 241, 255, 0.88);
   transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
 }
 
 .nav-dropdown-menu a:hover {
-  background: rgba(13, 79, 139, 0.1);
-  color: var(--ink-strong);
+  background: rgba(127, 205, 255, 0.14);
+  color: var(--white);
   transform: translateX(2px);
 }
 
 .nav-dropdown-menu a.active {
-  background: linear-gradient(90deg, rgba(13,79,139,0.16), rgba(13,79,139,0.1));
-  color: var(--primary-dark);
+  background: linear-gradient(90deg, rgba(127,205,255,0.28), rgba(127,205,255,0.16));
+  color: var(--white);
   font-weight: 600;
 }
 
@@ -407,9 +418,59 @@ img { max-width: 100%; height: auto; display: block; }
 
 .nav-links a:focus-visible,
 .nav-dropdown-trigger:focus-visible,
-.nav-dropdown-menu a:focus-visible {
+.nav-dropdown-menu a:focus-visible,
+.nav-cta:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px var(--nav-ring);
+}
+
+.nav-cta {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 205, 255, 0.35);
+  background: linear-gradient(135deg, rgba(127,205,255,0.24), rgba(101,169,255,0.36));
+  color: var(--white);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.nav-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(101, 169, 255, 0.35);
+  filter: brightness(1.05);
+}
+
+.nav-cta.active {
+  background: linear-gradient(135deg, rgba(127,205,255,0.36), rgba(127,205,255,0.52));
+  border-color: rgba(127, 205, 255, 0.55);
+}
+
+@media (max-width: 900px) {
+  .navbar .container {
+    padding: 0 14px;
+    border-radius: 18px;
+  }
+
+  .nav-links {
+    gap: 4px;
+  }
+
+  .nav-links a,
+  .nav-dropdown-trigger {
+    padding-inline: 11px;
+  }
+
+  .nav-cta {
+    padding: 10px 14px;
+    font-size: 12px;
+  }
 }
 
 @keyframes navMenuIn {
@@ -2116,6 +2177,13 @@ noscript + * .fade-in,
     border-bottom-color: transparent;
     backdrop-filter: none; -webkit-backdrop-filter: none;
   }
+  body.menu-open .navbar .container {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
   body.menu-open .navbar .nav-logo-mark {
     position: relative;
     z-index: 1225;
@@ -2124,6 +2192,7 @@ noscript + * .fade-in,
   body.menu-open .nav-mobile-toggle span { background: var(--mobile-menu-ink); }
 
   .nav-mobile-toggle { display: block; margin-left: auto; z-index: 1225; }
+  .nav-cta { display: none; }
 
   /* ── Drawer ── */
   .nav-links {

--- a/dev/ethics.html
+++ b/dev/ethics.html
@@ -24,7 +24,7 @@
         <li class="nav-dropdown nav-dropdown--active">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/ethics.html
+++ b/dev/ethics.html
@@ -33,10 +33,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -177,7 +177,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/events.html
+++ b/dev/events.html
@@ -22,7 +22,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/events.html
+++ b/dev/events.html
@@ -31,10 +31,10 @@
           </ul>
         </li>
         <li><a href="events.html" class="active"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -171,7 +171,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/index.html
+++ b/dev/index.html
@@ -34,11 +34,11 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
 
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span>
         <span></span>
@@ -216,7 +216,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/index.html
+++ b/dev/index.html
@@ -25,7 +25,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/js/main.js
+++ b/dev/js/main.js
@@ -306,15 +306,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const navbar = document.querySelector('.navbar');
 
-  window.addEventListener('scroll', () => {
-    const scrollY = window.scrollY;
+  function updateNavbarScrollState() {
+    if (!navbar) return;
+    navbar.classList.toggle('is-scrolled', window.scrollY > 10);
+  }
 
-    if (scrollY > 10) {
-      navbar.style.boxShadow = '0 1px 8px rgba(0,0,0,0.06)';
-    } else {
-      navbar.style.boxShadow = 'none';
-    }
-  }, { passive: true });
+  updateNavbarScrollState();
+  window.addEventListener('scroll', updateNavbarScrollState, { passive: true });
 
   document.querySelectorAll('.footer-year').forEach((el) => {
     el.textContent = String(new Date().getFullYear());

--- a/dev/privacy.html
+++ b/dev/privacy.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -151,7 +151,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/privacy.html
+++ b/dev/privacy.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -177,7 +177,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications/energy-footprint-reporting-standard.html
+++ b/dev/publications/energy-footprint-reporting-standard.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications/energy-footprint-reporting-standard.html
+++ b/dev/publications/energy-footprint-reporting-standard.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="../about.html"><span class="menu-label">About</span></a></li>
         <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="../publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -154,7 +154,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="../about.html"><span class="menu-label">About</span></a></li>
             <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications/human-oversight-design-patterns.html
+++ b/dev/publications/human-oversight-design-patterns.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="../about.html"><span class="menu-label">About</span></a></li>
         <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="../publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -157,7 +157,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="../about.html"><span class="menu-label">About</span></a></li>
             <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications/human-oversight-design-patterns.html
+++ b/dev/publications/human-oversight-design-patterns.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications/incident-reporting-playbook.html
+++ b/dev/publications/incident-reporting-playbook.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="../about.html"><span class="menu-label">About</span></a></li>
         <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="../publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -152,7 +152,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="../about.html"><span class="menu-label">About</span></a></li>
             <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications/incident-reporting-playbook.html
+++ b/dev/publications/incident-reporting-playbook.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications/participatory-ethics-municipal-ai.html
+++ b/dev/publications/participatory-ethics-municipal-ai.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="../about.html"><span class="menu-label">About</span></a></li>
         <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="../publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -151,7 +151,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="../about.html"><span class="menu-label">About</span></a></li>
             <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications/participatory-ethics-municipal-ai.html
+++ b/dev/publications/participatory-ethics-municipal-ai.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications/safety-evaluations-public-interest.html
+++ b/dev/publications/safety-evaluations-public-interest.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="../about.html"><span class="menu-label">About</span></a></li>
         <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="../publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -156,7 +156,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="../about.html"><span class="menu-label">About</span></a></li>
             <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications/safety-evaluations-public-interest.html
+++ b/dev/publications/safety-evaluations-public-interest.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/publications/sustainability-procurement-checklist.html
+++ b/dev/publications/sustainability-procurement-checklist.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="../publications.html" class="active"><span class="menu-label">Publications</span></a></li>
         <li><a href="../about.html"><span class="menu-label">About</span></a></li>
         <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="../publications.html" class="nav-cta active"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -152,7 +152,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="../events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="../publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="../about.html"><span class="menu-label">About</span></a></li>
             <li><a href="../contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="../privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications/sustainability-procurement-checklist.html
+++ b/dev/publications/sustainability-procurement-checklist.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="../safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/safety.html
+++ b/dev/safety.html
@@ -24,7 +24,7 @@
         <li class="nav-dropdown nav-dropdown--active">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem" class="active"><span class="menu-label">Safety</span></a></li>

--- a/dev/safety.html
+++ b/dev/safety.html
@@ -33,10 +33,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -173,7 +173,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/sustainability.html
+++ b/dev/sustainability.html
@@ -24,7 +24,7 @@
         <li class="nav-dropdown nav-dropdown--active">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>

--- a/dev/sustainability.html
+++ b/dev/sustainability.html
@@ -33,10 +33,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -173,7 +173,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/terms.html
+++ b/dev/terms.html
@@ -32,10 +32,10 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-        <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
+      <a href="publications.html" class="nav-cta"><span class="menu-label">View Publications</span></a>
       <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -136,7 +136,6 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
-            <li><a href="publications.html"><span class="menu-label">Publications</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/terms.html
+++ b/dev/terms.html
@@ -23,7 +23,7 @@
         <li class="nav-dropdown">
           <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
             <span class="menu-label">Research</span>
-            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 6v12M6 12h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <svg class="nav-chevron" width="15" height="15" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
             <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>


### PR DESCRIPTION
### Motivation
- Refresh the header and dropdown so the navigation feels modern, more usable, and more accessible across desktop and mobile viewports.

### Description
- Introduced new CSS tokens and updated `dev/css/styles.css` to add a glass-like nav surface, pill-style nav-group, refined hover/active states, and focus-visible rings for keyboard users.
- Reworked the desktop Research dropdown panel with a floating, blurred card, entrance animation, a caret pointer, richer item hover/active interactions, and improved spacing and radius.
- Replaced the plus glyph with a standard chevron SVG across site pages and made the chevron rotate to indicate open/closed state, updating multiple `dev/*.html` and `dev/publications/*.html` files.
- Replaced direct DOM box-shadow mutation with a scroll handler that toggles a CSS `is-scrolled` class in `dev/js/main.js`, and ensured the mobile drawer resets desktop pill/border styles inside the mobile breakpoint.

### Testing
- `node --check dev/js/main.js` — succeeded.
- `git diff --check` — succeeded (no leftover whitespace/merge errors found).
- Ran quick grep checks for the replaced plus-glyph pattern and updated files to confirm replacement — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed36fdd4b48320822fb2b4e9cea1a2)