### PR TITLE
Replace Oasis of Change .org links with .com and adjust footer anchor attributes

### DIFF
--- a/dev/about.html
+++ b/dev/about.html
@@ -154,7 +154,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/contact.html
+++ b/dev/contact.html
@@ -213,7 +213,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/ethics.html
+++ b/dev/ethics.html
@@ -186,7 +186,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/events.html
+++ b/dev/events.html
@@ -88,7 +88,7 @@
           <p class="events-luma-eyebrow">External calendar</p>
           <h3 class="events-luma-title" id="events-luma-heading">RSVP on Luma</h3>
           <p class="events-luma-copy">This page shows a quick month view. For registration, waitlists, and email updates, use our public Luma calendar (opens in a new tab).</p>
-          <a href="https://lu.ma/vcasse" class="btn btn-primary btn-uppercase events-luma-link events-luma-cta" target="_blank" rel="noopener noreferrer">
+          <a href="https://lu.ma/vcasse" class="btn btn-primary btn-uppercase events-luma-link events-luma-cta" target="_blank">
             <svg class="events-luma-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>
             Open Luma calendar
           </a>
@@ -180,7 +180,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/index.html
+++ b/dev/index.html
@@ -226,7 +226,7 @@
       </div>
 
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/privacy.html
+++ b/dev/privacy.html
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -186,7 +186,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications/energy-footprint-reporting-standard.html
+++ b/dev/publications/energy-footprint-reporting-standard.html
@@ -163,7 +163,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications/human-oversight-design-patterns.html
+++ b/dev/publications/human-oversight-design-patterns.html
@@ -166,7 +166,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications/incident-reporting-playbook.html
+++ b/dev/publications/incident-reporting-playbook.html
@@ -161,7 +161,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications/participatory-ethics-municipal-ai.html
+++ b/dev/publications/participatory-ethics-municipal-ai.html
@@ -160,7 +160,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications/safety-evaluations-public-interest.html
+++ b/dev/publications/safety-evaluations-public-interest.html
@@ -165,7 +165,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/publications/sustainability-procurement-checklist.html
+++ b/dev/publications/sustainability-procurement-checklist.html
@@ -161,7 +161,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/safety.html
+++ b/dev/safety.html
@@ -182,7 +182,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/sustainability.html
+++ b/dev/sustainability.html
@@ -182,7 +182,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/dev/terms.html
+++ b/dev/terms.html
@@ -145,7 +145,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.<span class="footer-separator">|</span>A subsidiary of <a href="https://oasisofchange.com" target="_blank"><span class="menu-label">OASIS OF CHANGE, INC.</span></a></p>
         <div class="footer-location">
           <svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
           Vancouver, BC, Canada

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
       </div>
       <p class="copyright">
         &copy; <script>document.write(new Date().getFullYear())</script> VCASSE.
-        A subsidiary of <a href="https://oasisofchange.org" target="_blank" rel="noopener noreferrer">Oasis of Change, Inc.</a>
+        A subsidiary of <a href="https://oasisofchange.com" target="_blank">Oasis of Change, Inc.</a>
       </p>
     </footer>
 


### PR DESCRIPTION
### Motivation
- Standardize the external organization link across the site to the correct `https://oasisofchange.com` domain.
- Keep footer and corporate attribution consistent across all pages and publication subpages.
- Remove redundant `rel="noopener noreferrer"` attributes where `target="_blank"` is already present to match the desired link attribute style.

### Description
- Updated the Oasis of Change external link from `https://oasisofchange.org` to `https://oasisofchange.com` in multiple pages including `index.html`, `dev/*.html`, and files under `dev/publications/`.
- Removed `rel="noopener noreferrer"` from the updated external anchor tags where present and kept `target="_blank"` for links that open in a new tab.
- Applied the same footer change consistently across top-level pages and nested publication pages so the site-wide footer now references the `.com` domain.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed37a558d88320926dbe198adad323)