### PR TITLE
Smooth the VCAS briefing handoff into the footer

### DIFF
--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -1301,7 +1301,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 .footer {
   background: var(--brand-band);
-  padding: 80px 0 0;
+  padding: 64px 0 0;
   position: relative;
   overflow: hidden;
 }
@@ -2952,13 +2952,37 @@ noscript + * .fade-in,
 /* ─────────────── NEWSLETTER COMING SOON ─────────────── */
 
 .newsletter-band {
-  padding: 72px 0 0;
+  position: relative;
+  padding: 72px 0 34px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 58%,
+    rgba(7, 35, 66, 0.22) 78%,
+    var(--brand-band) 100%
+  );
+}
+
+.newsletter-band::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 120px;
+  background: linear-gradient(
+    to bottom,
+    rgba(8, 42, 77, 0) 0%,
+    rgba(8, 42, 77, 0.45) 58%,
+    var(--brand-band) 100%
+  );
+  pointer-events: none;
 }
 
 .newsletter-card {
   background: linear-gradient(160deg, var(--bg-dark) 0%, var(--primary-dark) 60%, var(--primary) 130%);
   color: var(--white);
-  border-radius: 20px 20px 0 0;
+  border-radius: 20px;
   padding: 44px 48px;
   display: flex;
   gap: 40px;
@@ -2968,7 +2992,7 @@ noscript + * .fade-in,
   position: relative;
   overflow: hidden;
   box-shadow: 0 20px 48px -16px rgba(8, 42, 77, 0.45);
-  margin-bottom: -1px;
+  z-index: 1;
 }
 
 .newsletter-card::before {
@@ -3253,6 +3277,12 @@ noscript + * .fade-in,
     align-items: flex-start;
     gap: 24px;
   }
+  .newsletter-band {
+    padding: 64px 0 28px;
+  }
+  .newsletter-band::after {
+    height: 96px;
+  }
   .newsletter-form {
     max-width: 100%;
     width: 100%;
@@ -3297,8 +3327,14 @@ noscript + * .fade-in,
   }
   .newsletter-card {
     padding: 36px 24px;
-    border-radius: 16px 16px 0 0;
+    border-radius: 16px;
     align-items: stretch;
+  }
+  .newsletter-band {
+    padding: 56px 0 24px;
+  }
+  .newsletter-band::after {
+    height: 84px;
   }
   .newsletter-form {
     flex-direction: column;

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -1301,7 +1301,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 .footer {
   background: var(--brand-band);
-  padding: 80px 0 0;
+  padding: 64px 0 0;
   position: relative;
   overflow: hidden;
 }
@@ -2952,12 +2952,12 @@ noscript + * .fade-in,
 /* ─────────────── NEWSLETTER COMING SOON ─────────────── */
 
 .newsletter-band {
-  padding: 72px 0 24px;
-  background: var(--brand-band);
+  padding: 72px 0 0;
+  margin-bottom: 28px;
 }
 
 .newsletter-card {
-  background: linear-gradient(160deg, var(--bg-dark) 0%, var(--primary-dark) 60%, var(--primary) 130%);
+  background: var(--bg-dark);
   color: var(--white);
   border-radius: 20px;
   padding: 44px 48px;
@@ -2968,22 +2968,11 @@ noscript + * .fade-in,
   text-align: left;
   position: relative;
   overflow: hidden;
-  box-shadow: 0 20px 48px -16px rgba(8, 42, 77, 0.45);
-  z-index: 1;
-}
-
-.newsletter-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-  background-size: 22px 22px;
-  pointer-events: none;
+  box-shadow: 0 20px 48px -16px rgba(8, 42, 77, 0.35);
 }
 
 .newsletter-card > * {
   position: relative;
-  z-index: 1;
 }
 
 .newsletter-card h2 {
@@ -3255,7 +3244,8 @@ noscript + * .fade-in,
     gap: 24px;
   }
   .newsletter-band {
-    padding: 64px 0 20px;
+    padding: 64px 0 0;
+    margin-bottom: 24px;
   }
   .newsletter-form {
     max-width: 100%;
@@ -3305,7 +3295,8 @@ noscript + * .fade-in,
     align-items: stretch;
   }
   .newsletter-band {
-    padding: 56px 0 16px;
+    padding: 56px 0 0;
+    margin-bottom: 20px;
   }
   .newsletter-form {
     flex-direction: column;

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -1301,7 +1301,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 .footer {
   background: var(--brand-band);
-  padding: 64px 0 0;
+  padding: 80px 0 0;
   position: relative;
   overflow: hidden;
 }
@@ -2952,31 +2952,8 @@ noscript + * .fade-in,
 /* ─────────────── NEWSLETTER COMING SOON ─────────────── */
 
 .newsletter-band {
-  position: relative;
-  padding: 72px 0 34px;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 58%,
-    rgba(7, 35, 66, 0.22) 78%,
-    var(--brand-band) 100%
-  );
-}
-
-.newsletter-band::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 120px;
-  background: linear-gradient(
-    to bottom,
-    rgba(8, 42, 77, 0) 0%,
-    rgba(8, 42, 77, 0.45) 58%,
-    var(--brand-band) 100%
-  );
-  pointer-events: none;
+  padding: 72px 0 24px;
+  background: var(--brand-band);
 }
 
 .newsletter-card {
@@ -3278,10 +3255,7 @@ noscript + * .fade-in,
     gap: 24px;
   }
   .newsletter-band {
-    padding: 64px 0 28px;
-  }
-  .newsletter-band::after {
-    height: 96px;
+    padding: 64px 0 20px;
   }
   .newsletter-form {
     max-width: 100%;
@@ -3331,10 +3305,7 @@ noscript + * .fade-in,
     align-items: stretch;
   }
   .newsletter-band {
-    padding: 56px 0 24px;
-  }
-  .newsletter-band::after {
-    height: 84px;
+    padding: 56px 0 16px;
   }
   .newsletter-form {
     flex-direction: column;


### PR DESCRIPTION
### Motivation
- Improve the visual handoff between the VCASSE Briefing (newsletter) and the site footer so the section no longer ends with a hard seam. 
- Ensure the transition reads well at desktop, tablet, and mobile breakpoints for a softer, more polished UI.

### Description
- Add a gradient-backed transition on `.newsletter-band` and a layered `::after` overlay to create a smooth fade into the footer. 
- Make the `.newsletter-card` fully rounded and place it above the transition by setting `z-index: 1`. 
- Reduce the footer top padding by changing `.footer` from `padding: 80px 0 0` to `padding: 64px 0 0` to maintain balanced spacing with the new treatment. 
- Adjust responsive values inside the `@media` rules to tune `.newsletter-band` padding and the overlay `::after` height across tablet and mobile breakpoints.

### Testing
- Ran `git status --short` and `git diff -- dev/css/styles.css` to verify the working tree and inspect the CSS delta. 
- Committed the change successfully with `git commit` to record the update. 
- No unit or visual regression tests were run because this is a CSS-only change and visual verification should be performed in a browser or design review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3fb3e83883209fdab10412102a95)