### PR TITLE
Redesign publications page: simplified filters and updated visual layout

### DIFF
--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -2405,290 +2405,118 @@ noscript + * .fade-in,
 /* ─────────────── PUBLICATIONS INDEX PAGE ─────────────── */
 
 .publications-hero {
-  padding: 72px 0 48px;
-}
-
-.publications-hero .container {
-  align-items: center;
+  background: #d8e0e8;
+  padding: 74px 0 86px;
+  border-bottom: 1px solid #ccd5de;
 }
 
 .publications-hero .page-hero-title {
-  font-size: 60px;
+  max-width: 900px;
   margin-bottom: 22px;
-}
-
-.publications-hero-visual {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.publications-hero-stat-card {
-  background: var(--bg-dark);
-  color: rgba(226, 232, 240, 0.85);
-  border-radius: 18px;
-  padding: 28px 28px 24px;
-  width: 100%;
-  max-width: 320px;
-  box-shadow: 0 18px 40px -22px rgba(8, 42, 77, 0.55);
-  border: 1px solid rgba(108, 180, 228, 0.2);
-}
-
-.publications-hero-stat {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  margin-bottom: 18px;
-}
-
-.publications-hero-stat-num {
-  font-family: var(--font-display);
-  font-size: 56px;
-  font-weight: 700;
-  line-height: 1;
-  color: var(--white);
+  font-size: clamp(2.35rem, 5.2vw, 4.5rem);
+  line-height: 1.08;
   letter-spacing: -0.04em;
+  color: #0f172a;
 }
 
-.publications-hero-stat-label {
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgba(207, 226, 243, 0.7);
-}
-
-.publications-hero-pillars {
-  list-style: none;
-  display: grid;
-  gap: 8px;
-  border-top: 1px solid rgba(207, 226, 243, 0.15);
-  padding-top: 14px;
-  margin: 0 0 14px;
-}
-
-.publications-hero-pillars li {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 13px;
-  color: rgba(207, 226, 243, 0.75);
-}
-
-.publications-hero-pillars .publication-pill {
-  border: 1px solid transparent;
-}
-
-.publications-hero-note {
-  font-size: 12px;
-  color: rgba(207, 226, 243, 0.6);
-  margin: 0;
-  line-height: 1.55;
+.publications-hero .page-hero-description {
+  max-width: 760px;
+  font-size: clamp(1.15rem, 2.1vw, 2rem);
+  color: #334155;
 }
 
 .publications-toolbar-section {
-  background: var(--bg-light);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  padding: 18px 0;
-}
-
-.publications-toolbar {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 28px 0;
 }
 
 .publications-toolbar-row {
   display: flex;
   align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-
-.publications-toolbar-row--dense {
-  gap: 18px;
+  justify-content: space-between;
+  gap: 24px;
 }
 
 .publication-filters {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  gap: 12px;
   margin-bottom: 0;
 }
 
 .publication-filter {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 12px 7px 14px;
-}
-
-.publication-filter-count {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
-  min-width: 22px;
-  height: 20px;
-  padding: 0 7px;
+  padding: 9px 22px;
+  border: 1px solid #d6dbe2;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.06);
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  font-variant-numeric: tabular-nums;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.publication-filter:hover .publication-filter-count {
-  background: rgba(13, 79, 139, 0.1);
-  color: var(--primary);
-}
-
-.publication-filter.active .publication-filter-count {
-  background: rgba(255, 255, 255, 0.22);
-  color: var(--white);
+  background: transparent;
+  color: #1e293b;
+  font-size: clamp(1.1rem, 1.6vw, 1.9rem);
+  font-weight: 500;
+  line-height: 1.2;
+  transition: all 0.2s ease;
 }
 
 .publication-filter[data-pub-filter="all"].active {
-  background: var(--primary);
-  border-color: var(--primary);
+  background: #0d4f8b;
+  border-color: #0d4f8b;
   color: var(--white);
 }
 
 .publication-filter--safety.active {
-  background: #065f46;
-  border-color: #065f46;
-  color: #ecfdf5;
-}
-.publication-filter--safety.active .publication-filter-count {
-  background: rgba(255, 255, 255, 0.18);
-  color: #d1fae5;
+  background: #0d4f8b;
+  border-color: #0d4f8b;
+  color: #fff;
 }
 .publication-filter--safety:hover {
-  border-color: #a7f3d0;
-  color: #065f46;
+  border-color: #0d4f8b;
+  color: #0d4f8b;
 }
 
 .publication-filter--sustainability.active {
-  background: #0f766e;
-  border-color: #0f766e;
-  color: #ecfeff;
-}
-.publication-filter--sustainability.active .publication-filter-count {
-  background: rgba(255, 255, 255, 0.18);
-  color: #ccfbf1;
+  background: #0d4f8b;
+  border-color: #0d4f8b;
+  color: #fff;
 }
 .publication-filter--sustainability:hover {
-  border-color: #99f6e4;
-  color: #0f766e;
+  border-color: #0d4f8b;
+  color: #0d4f8b;
 }
 
 .publication-filter--ethics.active {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
-  color: #eff6ff;
-}
-.publication-filter--ethics.active .publication-filter-count {
-  background: rgba(255, 255, 255, 0.2);
-  color: #dbeafe;
+  background: #0d4f8b;
+  border-color: #0d4f8b;
+  color: #fff;
 }
 .publication-filter--ethics:hover {
-  border-color: #bfdbfe;
-  color: #1d4ed8;
-}
-
-.publications-search {
-  position: relative;
-  flex: 1 1 260px;
-  min-width: 220px;
-  max-width: 420px;
-}
-
-.publications-search-icon {
-  position: absolute;
-  top: 50%;
-  left: 14px;
-  transform: translateY(-50%);
-  width: 16px;
-  height: 16px;
-  color: var(--text-muted);
-  pointer-events: none;
-}
-
-.publications-search input {
-  width: 100%;
-  padding: 11px 14px 11px 40px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--bg-card);
-  font-family: var(--font-sans);
-  font-size: 14px;
-  color: var(--text-dark);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  outline: none;
-}
-
-.publications-search input::placeholder {
-  color: var(--text-light);
-}
-
-.publications-search input:focus {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(13, 79, 139, 0.12);
-}
-
-.publications-select-group {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: var(--text-muted);
-}
-
-.publications-select-group label {
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  font-size: 11px;
-  color: var(--text-muted);
-}
-
-.publications-select-group select {
-  padding: 8px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--bg-card);
-  font-family: var(--font-sans);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-dark);
-  cursor: pointer;
+  border-color: #0d4f8b;
+  color: #0d4f8b;
 }
 
 .publications-count {
-  margin: 0 0 0 auto;
   display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: 13px;
-  color: var(--text-muted);
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: #475569;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.9rem;
 }
 
 .publications-count-num {
-  font-family: var(--font-display);
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--text-dark);
-  letter-spacing: -0.01em;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #334155;
   font-variant-numeric: tabular-nums;
 }
 
 .publications-count-label {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 1rem;
+  font-weight: 500;
 }
 
 .publications-grid {
@@ -2699,7 +2527,11 @@ noscript + * .fade-in,
 
 .publication-card--with-cover {
   padding: 0;
+  background: #fff;
+  border: 1px solid #d8dee6;
+  border-radius: 20px;
   overflow: hidden;
+  box-shadow: none;
 }
 
 .publication-card-cover {
@@ -2725,27 +2557,29 @@ noscript + * .fade-in,
   position: absolute;
   top: 14px;
   left: 14px;
-  background: rgba(255, 255, 255, 0.96);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04), 0 6px 16px -10px rgba(15, 23, 42, 0.4);
+  background: #b4f0d6;
+  color: #085746;
+  border: 0;
+  box-shadow: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 .publication-card-body {
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: 22px;
+  padding: 26px 24px 30px;
 }
 
 .publication-card-body h3 {
   font-family: var(--font-display);
-  font-size: 1.15rem;
+  font-size: clamp(1.85rem, 2vw, 2.1rem);
   font-weight: 600;
   color: var(--text-dark);
   letter-spacing: -0.02em;
-  margin-bottom: 10px;
-  line-height: 1.3;
+  margin-bottom: 0;
+  line-height: 1.22;
 }
 
 .publication-card-body h3 a {
@@ -2756,59 +2590,10 @@ noscript + * .fade-in,
   color: var(--primary);
 }
 
-.publication-card-body p {
-  font-size: 14px;
-  line-height: 1.65;
-  color: var(--text-body);
+.publication-card-meta {
+  font-size: 1rem;
+  color: #64748b;
   margin-bottom: 14px;
-}
-
-.publication-card-authors {
-  font-size: 12px !important;
-  color: var(--text-muted) !important;
-  margin-top: -6px;
-  margin-bottom: 14px !important;
-}
-
-.publications-empty {
-  text-align: center;
-  padding: 56px 24px 60px;
-  background: var(--bg-light);
-  border: 1px dashed var(--border);
-  border-radius: var(--radius-lg);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-}
-
-.publications-empty[hidden],
-.publications-grid[hidden] {
-  display: none;
-}
-
-.publications-empty-icon {
-  width: 44px;
-  height: 44px;
-  color: var(--primary);
-  opacity: 0.55;
-  margin-bottom: 4px;
-}
-
-.publications-empty h3 {
-  font-family: var(--font-display);
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--text-dark);
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-
-.publications-empty p {
-  font-size: 14px;
-  color: var(--text-muted);
-  margin: 0 0 8px;
-  max-width: 380px;
 }
 
 /* ─────────────── PUBLICATION DETAIL PAGE ─────────────── */
@@ -3326,17 +3111,10 @@ noscript + * .fade-in,
     position: static;
   }
   .publications-hero {
-    padding: 56px 0 32px;
-  }
-  .publications-hero .container {
-    grid-template-columns: 1fr;
-    gap: 0;
+    padding: 56px 0 64px;
   }
   .publications-hero .page-hero-title {
     font-size: 48px;
-  }
-  .publications-hero-visual {
-    display: none;
   }
   .newsletter-card {
     padding: 40px 36px;
@@ -3360,15 +3138,7 @@ noscript + * .fade-in,
   }
   .publications-toolbar-row {
     flex-direction: column;
-    align-items: stretch;
-  }
-  .publications-toolbar-row--dense {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-  .publications-search {
-    flex: 1 1 auto;
-    max-width: none;
+    align-items: flex-start;
   }
   .publication-filters {
     overflow-x: auto;
@@ -3377,8 +3147,7 @@ noscript + * .fade-in,
     -webkit-overflow-scrolling: touch;
   }
   .publications-count {
-    margin-left: 0;
-    width: 100%;
+    width: auto;
   }
   .publication-detail-hero {
     padding: 48px 0 56px;

--- a/dev/js/publications-page.js
+++ b/dev/js/publications-page.js
@@ -12,19 +12,10 @@
     if (!grid || typeof window.getPublications !== 'function') return;
 
     const posts = window.getPublications();
-    updateHeroStats(posts);
-    populateFilterCounts(posts);
     const filterButtons = Array.from(document.querySelectorAll('[data-pub-filter]'));
-    const tagSelect = document.getElementById('publicationsTag');
-    const sortSelect = document.getElementById('publicationsSort');
-    const searchInput = document.getElementById('publicationsSearch');
     const resultsCount = document.getElementById('publicationsCount');
-    const emptyState = document.getElementById('publicationsEmpty');
-    const resetBtn = document.getElementById('publicationsReset');
 
-    const state = { pillar: 'all', tag: 'all', sort: 'newest', query: '' };
-
-    populateTags(tagSelect, posts);
+    const state = { pillar: 'all' };
     render();
 
     filterButtons.forEach((btn) => {
@@ -36,132 +27,16 @@
       });
     });
 
-    if (tagSelect) {
-      tagSelect.addEventListener('change', () => {
-        state.tag = tagSelect.value;
-        render();
-      });
-    }
-
-    if (sortSelect) {
-      sortSelect.addEventListener('change', () => {
-        state.sort = sortSelect.value;
-        render();
-      });
-    }
-
-    if (searchInput) {
-      let timer;
-      searchInput.addEventListener('input', () => {
-        clearTimeout(timer);
-        timer = setTimeout(() => {
-          state.query = searchInput.value.trim().toLowerCase();
-          render();
-        }, 120);
-      });
-    }
-
-    if (resetBtn) {
-      resetBtn.addEventListener('click', () => {
-        state.pillar = 'all';
-        state.tag = 'all';
-        state.sort = 'newest';
-        state.query = '';
-        if (searchInput) searchInput.value = '';
-        if (tagSelect) tagSelect.value = 'all';
-        if (sortSelect) sortSelect.value = 'newest';
-        filterButtons.forEach((b) => {
-          const isAll = b.getAttribute('data-pub-filter') === 'all';
-          b.classList.toggle('active', isAll);
-          b.setAttribute('aria-pressed', String(isAll));
-        });
-        render();
-      });
-    }
-
-    function populateTags(select, list) {
-      if (!select) return;
-      const tags = new Set();
-      list.forEach((p) => p.tags.forEach((t) => tags.add(t)));
-      const sorted = Array.from(tags).sort((a, b) => a.localeCompare(b));
-      sorted.forEach((tag) => {
-        const opt = document.createElement('option');
-        opt.value = tag;
-        opt.textContent = tag;
-        select.appendChild(opt);
-      });
-    }
-
     function render() {
-      const filtered = posts.filter((post) => {
-        if (state.pillar !== 'all' && post.pillar !== state.pillar) return false;
-        if (state.tag !== 'all' && !post.tags.includes(state.tag)) return false;
-        if (state.query) {
-          const haystack = [post.title, post.excerpt, post.tags.join(' '), (post.authors || []).join(' ')]
-            .join(' ')
-            .toLowerCase();
-          if (!haystack.includes(state.query)) return false;
-        }
-        return true;
-      });
-
-      filtered.sort((a, b) => {
-        if (state.sort === 'oldest') return new Date(a.date) - new Date(b.date);
-        if (state.sort === 'az') return a.title.localeCompare(b.title);
-        return new Date(b.date) - new Date(a.date);
-      });
+      const filtered = posts.filter((post) => state.pillar === 'all' || post.pillar === state.pillar);
 
       grid.innerHTML = '';
       filtered.forEach((post) => grid.appendChild(buildCard(post)));
 
       if (resultsCount) {
-        const total = posts.length;
-        const shown = filtered.length;
         const numEl = resultsCount.querySelector('.publications-count-num');
-        const labelEl = resultsCount.querySelector('.publications-count-label');
-        if (numEl && labelEl) {
-          numEl.textContent = shown === total ? String(total) : `${shown} / ${total}`;
-          labelEl.textContent = shown === 1 ? 'publication' : 'publications';
-        } else {
-          resultsCount.textContent = shown === total
-            ? `Showing all ${total} publications`
-            : `Showing ${shown} of ${total} publications`;
-        }
+        if (numEl) numEl.textContent = String(filtered.length);
       }
-
-      if (emptyState) {
-        emptyState.hidden = filtered.length > 0;
-      }
-      grid.hidden = filtered.length === 0;
-    }
-
-    function populateFilterCounts(list) {
-      const counts = list.reduce((acc, p) => {
-        acc[p.pillar] = (acc[p.pillar] || 0) + 1;
-        return acc;
-      }, {});
-      counts.all = list.length;
-      document.querySelectorAll('[data-pub-count]').forEach((el) => {
-        const key = el.getAttribute('data-pub-count');
-        el.textContent = String(counts[key] || 0);
-      });
-    }
-
-    function updateHeroStats(list) {
-      const total = list.length;
-      const heroCount = document.getElementById('publicationsHeroCount');
-      if (heroCount) heroCount.textContent = String(total);
-      const pillarCounts = list.reduce((acc, p) => {
-        acc[p.pillar] = (acc[p.pillar] || 0) + 1;
-        return acc;
-      }, {});
-      document.querySelectorAll('.publications-hero-pillars li').forEach((li) => {
-        const pill = li.querySelector('.publication-pill');
-        if (!pill) return;
-        const key = ['safety', 'sustainability', 'ethics'].find((k) => pill.classList.contains(`publication-pill--${k}`));
-        const valueEl = li.querySelector('span:last-child');
-        if (key && valueEl) valueEl.textContent = String(pillarCounts[key] || 0);
-      });
     }
 
     function buildCard(post) {
@@ -171,9 +46,6 @@
 
       const pillarLabel = PILLAR_LABELS[post.pillar] || post.pillar;
       const dateText = formatDate(post.date);
-      const tags = post.tags.map((t) => `<li>${escapeHtml(t)}</li>`).join('');
-      const authors = (post.authors || []).join(', ');
-
       article.innerHTML = `
         <a class="publication-card-cover" href="${post.url}" aria-label="Read ${escapeHtml(post.title)}">
           <img src="${post.cover}" alt="" loading="lazy" decoding="async">
@@ -186,10 +58,6 @@
             <span>${escapeHtml(post.readingTime)}</span>
           </div>
           <h3><a href="${post.url}">${escapeHtml(post.title)}</a></h3>
-          <p>${escapeHtml(post.excerpt)}</p>
-          ${authors ? `<p class="publication-card-authors">By ${escapeHtml(authors)}</p>` : ''}
-          <ul class="publication-tags">${tags}</ul>
-          <a class="modern-card-link" href="${post.url}">Read publication <span aria-hidden="true">→</span></a>
         </div>
       `;
       return article;

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -52,26 +52,9 @@
     <div class="container">
       <div class="page-hero-content">
         <div class="section-label">PUBLICATIONS</div>
-        <h1 class="page-hero-title">
-          Policy briefs,
-          <span class="italic-accent">research &amp; explainers</span>
-        </h1>
-        <p class="page-hero-description">VCASSE publishes practical research across Safety, Sustainability, and Ethics &mdash; written to inform Vancouver's policymakers, developers, and residents as AI reshapes public life.</p>
+        <h1 class="page-hero-title">Plain-language briefs &amp; field guides on responsible AI.</h1>
+        <p class="page-hero-description">Short, practical, and freely available. Six per year, on average.</p>
       </div>
-      <aside class="publications-hero-visual" aria-hidden="true">
-        <div class="publications-hero-stat-card">
-          <div class="publications-hero-stat">
-            <span class="publications-hero-stat-num" id="publicationsHeroCount">6</span>
-            <span class="publications-hero-stat-label">publications</span>
-          </div>
-          <ul class="publications-hero-pillars">
-            <li><span class="publication-pill publication-pill--safety">Safety</span><span>2</span></li>
-            <li><span class="publication-pill publication-pill--sustainability">Sustainability</span><span>2</span></li>
-            <li><span class="publication-pill publication-pill--ethics">Ethics</span><span>2</span></li>
-          </ul>
-          <p class="publications-hero-note">Updated continuously as our research program grows.</p>
-        </div>
-      </aside>
     </div>
   </section>
 
@@ -82,44 +65,20 @@
           <div class="publication-filters" role="group" aria-label="Filter by pillar">
             <button type="button" class="publication-filter active" data-pub-filter="all" aria-pressed="true">
               <span class="publication-filter-label">All</span>
-              <span class="publication-filter-count" data-pub-count="all">6</span>
             </button>
             <button type="button" class="publication-filter publication-filter--safety" data-pub-filter="safety" aria-pressed="false">
               <span class="publication-filter-label">Safety</span>
-              <span class="publication-filter-count" data-pub-count="safety">0</span>
             </button>
             <button type="button" class="publication-filter publication-filter--sustainability" data-pub-filter="sustainability" aria-pressed="false">
               <span class="publication-filter-label">Sustainability</span>
-              <span class="publication-filter-count" data-pub-count="sustainability">0</span>
             </button>
             <button type="button" class="publication-filter publication-filter--ethics" data-pub-filter="ethics" aria-pressed="false">
               <span class="publication-filter-label">Ethics</span>
-              <span class="publication-filter-count" data-pub-count="ethics">0</span>
             </button>
-          </div>
-          <div class="publications-search">
-            <svg class="publications-search-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M10 2a8 8 0 1 0 5.3 14.06l4.33 4.33 1.42-1.42-4.33-4.33A8 8 0 0 0 10 2zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12z" fill="currentColor"/></svg>
-            <input type="search" id="publicationsSearch" placeholder="Search title, tag, or author" aria-label="Search publications">
-          </div>
-        </div>
-        <div class="publications-toolbar-row publications-toolbar-row--dense">
-          <div class="publications-select-group">
-            <label for="publicationsTag">Tag</label>
-            <select id="publicationsTag">
-              <option value="all">All tags</option>
-            </select>
-          </div>
-          <div class="publications-select-group">
-            <label for="publicationsSort">Sort</label>
-            <select id="publicationsSort">
-              <option value="newest">Newest first</option>
-              <option value="oldest">Oldest first</option>
-              <option value="az">A &ndash; Z</option>
-            </select>
           </div>
           <p class="publications-count" id="publicationsCount" aria-live="polite">
             <span class="publications-count-num">6</span>
-            <span class="publications-count-label">publications</span>
+            <span class="publications-count-label">Items</span>
           </p>
         </div>
       </div>
@@ -129,16 +88,6 @@
   <section class="home-section publications-index">
     <div class="container">
       <div class="publications-grid" id="publicationsGrid" aria-live="polite"></div>
-      <div class="publications-empty" id="publicationsEmpty" hidden>
-        <svg class="publications-empty-icon" viewBox="0 0 64 64" aria-hidden="true">
-          <circle cx="28" cy="28" r="18" fill="none" stroke="currentColor" stroke-width="2.5"/>
-          <line x1="42" y1="42" x2="56" y2="56" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
-          <line x1="22" y1="28" x2="34" y2="28" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.5"/>
-        </svg>
-        <h3>Nothing matches those filters.</h3>
-        <p>Try a broader pillar, clear the search, or reset everything.</p>
-        <button type="button" class="btn btn-secondary" id="publicationsReset">Reset filters</button>
-      </div>
     </div>
   </section>
 


### PR DESCRIPTION
### Motivation
- Align the publications index with the provided design comp by replacing the hero copy and visual treatment and simplifying controls. 
- Surface a cleaner, publication-focused grid with pill-style pillar filters and a concise right-aligned item count for faster scanning. 

### Description
- Updated `dev/publications.html` to replace the hero headline/subhead, remove the old hero stat card and secondary controls, and simplify the toolbar to pillar filter pills plus a right-aligned `Items` count. 
- Refactored `dev/js/publications-page.js` to remove tag/sort/search/reset flows and implement a streamlined pillar-only filtering flow that renders compact cards (cover, pill, date/read-time, title) and updates the live item count. 
- Restyled the publications area in `dev/css/styles.css` to implement the soft gray hero band, larger hero/type scale, pill filter treatment, bordered publication cards with rounded corners, and responsive adjustments matching the simplified layout. 

### Testing
- Verified JavaScript parses with Node using `new Function(...)` which succeeded and printed a parse confirmation. 
- Reviewed file diffs to confirm only intended UI/behavioral code was removed or simplified (no automated visual tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed46b6f0188320921befee2406c379)