### PR TITLE
Add five example widgets demonstrating new feature ideas

### DIFF
--- a/examples/carbon-calculator.html
+++ b/examples/carbon-calculator.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Carbon Footprint Calculator — VCASSE</title>
+  <link rel="stylesheet" href="css/examples.css">
+  <link rel="icon" type="image/svg+xml" href="../dev/img/logo.svg">
+</head>
+<body>
+
+  <nav class="examples-nav">
+    <div class="container">
+      <a href="../dev/index.html" class="examples-nav-brand">
+        <span class="examples-nav-brand-mark">V</span>
+        <span>VCASSE</span>
+      </a>
+      <span class="examples-nav-tag">Widget · Sustainability</span>
+      <a href="index.html" class="examples-nav-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        All widgets
+      </a>
+    </div>
+  </nav>
+
+  <header class="example-hero">
+    <div class="container">
+      <p class="example-hero-kicker">AI Carbon Footprint Calculator</p>
+      <h1 class="example-hero-title">What does a week of <em>your AI use</em> actually cost the planet?</h1>
+      <p class="example-hero-lede">
+        Estimates the energy, water, and CO₂ associated with how you use AI in a typical week.
+        Numbers are illustrative — built on published per-query estimates for current
+        commercial models — and are translated into everyday equivalents.
+      </p>
+    </div>
+  </header>
+
+  <main class="example-section">
+    <div class="container">
+      <div class="calc-grid">
+
+        <section class="panel" aria-labelledby="calc-input-title">
+          <h2 class="panel-title" id="calc-input-title">Tell us about a typical week</h2>
+          <p class="panel-sub">Drag the sliders. Numbers update as you go.</p>
+
+          <div class="calc-input-group">
+            <label for="chats">
+              Short chat messages per day
+              <span class="calc-value"><span data-out="chats">20</span></span>
+            </label>
+            <input class="calc-slider" type="range" id="chats" min="0" max="200" value="20">
+          </div>
+
+          <div class="calc-input-group">
+            <label for="long">
+              Long-form generations per day <small style="font-weight:400;color:var(--text-muted);">(essays, reports)</small>
+              <span class="calc-value"><span data-out="long">3</span></span>
+            </label>
+            <input class="calc-slider" type="range" id="long" min="0" max="50" value="3">
+          </div>
+
+          <div class="calc-input-group">
+            <label for="images">
+              AI images generated per day
+              <span class="calc-value"><span data-out="images">2</span></span>
+            </label>
+            <input class="calc-slider" type="range" id="images" min="0" max="50" value="2">
+          </div>
+
+          <div class="calc-input-group">
+            <label for="model">Default model class</label>
+            <select id="model" class="calc-select">
+              <option value="small">Small / efficient (e.g. 8B distilled)</option>
+              <option value="mid" selected>Mid-size general assistant</option>
+              <option value="frontier">Frontier model (largest available)</option>
+            </select>
+          </div>
+
+          <div class="calc-input-group">
+            <label for="grid">Where the data centre runs</label>
+            <select id="grid" class="calc-select">
+              <option value="bc" selected>BC / Pacific NW (mostly hydro)</option>
+              <option value="us">U.S. national average grid</option>
+              <option value="coal">Coal-heavy grid</option>
+            </select>
+          </div>
+        </section>
+
+        <aside class="calc-results" aria-live="polite">
+          <p class="calc-results-headline">Estimated weekly footprint</p>
+          <div class="calc-results-number"><span id="co2-out">0</span></div>
+          <div class="calc-results-unit">grams CO₂-equivalent</div>
+
+          <div class="calc-breakdown">
+            <div class="calc-breakdown-row">
+              <span>Electricity</span>
+              <span><span id="kwh-out">0</span> Wh</span>
+            </div>
+            <div class="calc-breakdown-row">
+              <span>Water (cooling)</span>
+              <span><span id="water-out">0</span> mL</span>
+            </div>
+            <div class="calc-breakdown-row">
+              <span>Annual projection</span>
+              <span><span id="annual-out">0</span> kg CO₂e</span>
+            </div>
+          </div>
+
+          <div class="calc-equiv" id="equiv-out"></div>
+
+          <p style="font-size:11px;color:rgba(255,255,255,0.55);margin-top:18px;line-height:1.5;">
+            Estimates only. Per-query figures are drawn from public reporting on
+            commercial AI inference and vary widely by provider. VCASSE publishes
+            updated assumptions in our sustainability briefs.
+          </p>
+        </aside>
+      </div>
+
+      <p class="example-footnote">
+        Want help building <strong>real</strong> reporting like this for your team or municipality?
+        That is exactly the kind of work VCASSE's sustainability pillar takes on.
+      </p>
+    </div>
+  </main>
+
+  <script src="js/carbon-calculator.js"></script>
+</body>
+</html>

--- a/examples/carbon-calculator.html
+++ b/examples/carbon-calculator.html
@@ -40,8 +40,18 @@
       <div class="calc-grid">
 
         <section class="panel" aria-labelledby="calc-input-title">
-          <h2 class="panel-title" id="calc-input-title">Tell us about a typical week</h2>
-          <p class="panel-sub">Drag the sliders. Numbers update as you go.</p>
+          <header class="calc-panel-header">
+            <div>
+              <h2 class="panel-title" id="calc-input-title">Tell us about a typical week</h2>
+              <p class="panel-sub" style="margin-bottom:0;">Drag the sliders. Numbers update as you go.</p>
+            </div>
+            <div class="calc-presets" role="group" aria-label="Quick presets">
+              <button type="button" class="calc-preset" data-preset="light">Light</button>
+              <button type="button" class="calc-preset is-active" data-preset="typical">Typical</button>
+              <button type="button" class="calc-preset" data-preset="heavy">Heavy</button>
+              <button type="button" class="calc-preset" data-preset="power">Power user</button>
+            </div>
+          </header>
 
           <div class="calc-input-group">
             <label for="chats">
@@ -60,6 +70,14 @@
           </div>
 
           <div class="calc-input-group">
+            <label for="code">
+              Code completions / dev queries per day
+              <span class="calc-value"><span data-out="code">15</span></span>
+            </label>
+            <input class="calc-slider" type="range" id="code" min="0" max="500" value="15">
+          </div>
+
+          <div class="calc-input-group">
             <label for="images">
               AI images generated per day
               <span class="calc-value"><span data-out="images">2</span></span>
@@ -68,21 +86,39 @@
           </div>
 
           <div class="calc-input-group">
-            <label for="model">Default model class</label>
-            <select id="model" class="calc-select">
-              <option value="small">Small / efficient (e.g. 8B distilled)</option>
-              <option value="mid" selected>Mid-size general assistant</option>
-              <option value="frontier">Frontier model (largest available)</option>
-            </select>
+            <label for="voice">
+              Voice / audio minutes per day <small style="font-weight:400;color:var(--text-muted);">(transcription, TTS)</small>
+              <span class="calc-value"><span data-out="voice">0</span></span>
+            </label>
+            <input class="calc-slider" type="range" id="voice" min="0" max="120" value="0">
           </div>
 
           <div class="calc-input-group">
-            <label for="grid">Where the data centre runs</label>
-            <select id="grid" class="calc-select">
-              <option value="bc" selected>BC / Pacific NW (mostly hydro)</option>
-              <option value="us">U.S. national average grid</option>
-              <option value="coal">Coal-heavy grid</option>
-            </select>
+            <label for="video">
+              AI video clips generated per week
+              <span class="calc-value"><span data-out="video">0</span></span>
+            </label>
+            <input class="calc-slider" type="range" id="video" min="0" max="20" value="0">
+          </div>
+
+          <div class="calc-row-2">
+            <div class="calc-input-group">
+              <label for="model">Default model class</label>
+              <select id="model" class="calc-select">
+                <option value="small">Small / efficient (8B distilled)</option>
+                <option value="mid" selected>Mid-size general assistant</option>
+                <option value="frontier">Frontier model (largest available)</option>
+              </select>
+            </div>
+
+            <div class="calc-input-group">
+              <label for="grid">Data-centre grid</label>
+              <select id="grid" class="calc-select">
+                <option value="bc" selected>BC / Pacific NW (mostly hydro)</option>
+                <option value="us">U.S. national average</option>
+                <option value="coal">Coal-heavy grid</option>
+              </select>
+            </div>
           </div>
         </section>
 
@@ -90,6 +126,8 @@
           <p class="calc-results-headline">Estimated weekly footprint</p>
           <div class="calc-results-number"><span id="co2-out">0</span></div>
           <div class="calc-results-unit">grams CO₂-equivalent</div>
+
+          <div class="calc-bench" id="bench-out"></div>
 
           <div class="calc-breakdown">
             <div class="calc-breakdown-row">
@@ -106,9 +144,17 @@
             </div>
           </div>
 
+          <div class="calc-attr">
+            <p class="calc-attr-title">Where it comes from</p>
+            <div class="calc-attr-bar" id="attr-bar" role="img" aria-label="Activity attribution"></div>
+            <ul class="calc-attr-legend" id="attr-legend"></ul>
+          </div>
+
           <div class="calc-equiv" id="equiv-out"></div>
 
-          <p style="font-size:11px;color:rgba(255,255,255,0.55);margin-top:18px;line-height:1.5;">
+          <div class="calc-tips" id="tips-out"></div>
+
+          <p class="calc-disclaimer">
             Estimates only. Per-query figures are drawn from public reporting on
             commercial AI inference and vary widely by provider. VCASSE publishes
             updated assumptions in our sustainability briefs.

--- a/examples/css/examples.css
+++ b/examples/css/examples.css
@@ -626,20 +626,229 @@ button { font: inherit; cursor: pointer; }
 
 .calc-equiv strong { color: var(--white); }
 
+/* Header row: title + presets */
+.calc-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 22px;
+}
+
+.calc-presets {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  background: var(--bg-card-alt);
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.calc-preset {
+  background: transparent;
+  border: none;
+  color: var(--text-body);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 999px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.calc-preset:hover { color: var(--primary-dark); }
+
+.calc-preset.is-active {
+  background: var(--primary);
+  color: var(--white);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+/* Two-column row inside the input panel */
+.calc-row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 540px) {
+  .calc-row-2 { grid-template-columns: 1fr; gap: 0; }
+}
+
+/* Benchmark pill on results panel */
+.calc-bench {
+  margin-top: 14px;
+  min-height: 28px;
+}
+
+.calc-bench-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.1);
+  color: rgba(255,255,255,0.9);
+}
+
+.calc-bench-pill::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.calc-bench--low  { color: #9be3c2; }
+.calc-bench--mid  { color: #f3d784; }
+.calc-bench--high { color: #f6a48a; }
+
+/* Activity attribution */
+.calc-attr {
+  margin-top: 22px;
+}
+
+.calc-attr-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.65);
+  margin-bottom: 10px;
+}
+
+.calc-attr-bar {
+  display: flex;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255,255,255,0.08);
+}
+
+.calc-attr-seg {
+  height: 100%;
+  display: block;
+  transition: width 0.35s ease;
+}
+
+.calc-attr-empty {
+  font-size: 12px;
+  color: rgba(255,255,255,0.55);
+  font-style: italic;
+}
+
+.calc-attr-legend {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px 14px;
+}
+
+.calc-attr-legend li {
+  display: grid;
+  grid-template-columns: 12px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.85);
+}
+
+.calc-attr-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+.calc-attr-pct {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: rgba(255,255,255,0.7);
+}
+
+/* Tips list */
+.calc-tips {
+  margin-top: 18px;
+}
+
+.calc-tips:empty { display: none; }
+
+.calc-tips-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.65);
+  margin-bottom: 8px;
+}
+
+.calc-tips-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.calc-tips-list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: rgba(255,255,255,0.88);
+}
+
+.calc-tips-list li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--green-accent);
+  font-weight: 600;
+}
+
+.calc-tips-list strong { color: var(--white); }
+
+.calc-disclaimer {
+  font-size: 11px;
+  color: rgba(255,255,255,0.55);
+  margin-top: 18px;
+  line-height: 1.5;
+}
+
 /* ─────────────── Glossary ─────────────── */
 
 .glossary-controls {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
   gap: 12px;
-  margin-bottom: 24px;
+  margin-bottom: 18px;
+}
+
+.glossary-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.glossary-search-icon {
+  position: absolute;
+  left: 14px;
+  color: var(--text-muted);
+  pointer-events: none;
 }
 
 .glossary-search {
   flex: 1;
   min-width: 240px;
-  padding: 12px 16px;
+  padding: 12px 56px 12px 40px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--white);
@@ -652,6 +861,20 @@ button { font: inherit; cursor: pointer; }
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(13, 79, 139, 0.12);
+}
+
+.glossary-shortcut {
+  position: absolute;
+  right: 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-light);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 2px 6px;
+  pointer-events: none;
 }
 
 .glossary-filters {
@@ -671,11 +894,68 @@ button { font: inherit; cursor: pointer; }
   transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
+.glossary-filter:hover { color: var(--primary-dark); }
+
 .glossary-filter.is-active {
   background: var(--primary);
   border-color: var(--primary);
   color: var(--white);
 }
+
+.glossary-filter--level.is-active {
+  background: var(--ink-strong);
+  border-color: var(--ink-strong);
+}
+
+.glossary-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-light);
+}
+
+.glossary-count {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.glossary-count strong {
+  color: var(--text-dark);
+  font-weight: 600;
+}
+
+.glossary-letters {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+.glossary-letter {
+  background: transparent;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--primary);
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.glossary-letter:hover { background: rgba(13, 79, 139, 0.08); }
+
+.glossary-letter.is-disabled {
+  color: var(--text-light);
+  cursor: not-allowed;
+}
+
+.glossary-letter.is-disabled:hover { background: transparent; }
 
 .glossary-list {
   display: grid;
@@ -708,12 +988,76 @@ button { font: inherit; cursor: pointer; }
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--ink-strong);
+  cursor: pointer;
+  transition: color 0.15s ease;
 }
+
+.glossary-term:hover {
+  color: var(--primary);
+}
+
+.glossary-term.is-copied {
+  color: var(--success);
+}
+
+.glossary-level {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  background: var(--bg-card-alt);
+  color: var(--text-muted);
+}
+
+.glossary-level--beginner     { background: rgba(31, 138, 107, 0.12); color: var(--sustainability); }
+.glossary-level--intermediate { background: rgba(13, 79, 139, 0.10);  color: var(--primary); }
+.glossary-level--advanced     { background: rgba(138, 74, 138, 0.12); color: var(--ethics); }
 
 .glossary-def {
   font-size: 0.93rem;
   color: var(--text-body);
   line-height: 1.6;
+}
+
+.glossary-def mark {
+  background: #fff3cd;
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 2px;
+}
+
+.glossary-seealso {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.glossary-seealso > span {
+  font-weight: 600;
+  color: var(--text-body);
+}
+
+.glossary-xref {
+  color: var(--primary);
+  font-weight: 500;
+  border-bottom: 1px dashed rgba(13, 79, 139, 0.35);
+}
+
+.glossary-xref:hover {
+  color: var(--primary-dark);
+  border-bottom-color: var(--primary-dark);
+}
+
+@keyframes glossaryFlash {
+  0%   { background: rgba(255, 230, 138, 0.55); border-color: rgba(194, 65, 12, 0.4); }
+  100% { background: var(--bg-card); border-color: var(--border); }
+}
+
+.glossary-item.is-flash {
+  animation: glossaryFlash 1.6s ease-out;
 }
 
 .glossary-empty {
@@ -796,6 +1140,317 @@ button { font: inherit; cursor: pointer; }
   font-size: 0.93rem;
   color: var(--text-body);
   margin-bottom: 16px;
+}
+
+.tracker-item-target {
+  color: var(--text-muted);
+  display: inline;
+}
+
+/* Toolbar above the brief list */
+.tracker-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.tracker-toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.tracker-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.tracker-search-icon {
+  position: absolute;
+  left: 14px;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.tracker-search {
+  width: 100%;
+  padding: 12px 16px 12px 40px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--white);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  color: var(--text-dark);
+}
+
+.tracker-search:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(13, 79, 139, 0.12);
+}
+
+.tracker-select {
+  width: auto;
+  min-width: 220px;
+  padding: 9px 14px;
+  font-size: 0.9rem;
+}
+
+.tracker-view-toggle {
+  display: inline-flex;
+  background: var(--bg-card-alt);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px;
+  margin-left: auto;
+}
+
+.tracker-view-toggle button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-body);
+  padding: 6px 12px;
+  border-radius: 999px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tracker-view-toggle button:hover { color: var(--primary-dark); }
+
+.tracker-view-toggle button.is-active {
+  background: var(--white);
+  color: var(--primary-dark);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.tracker-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  margin-bottom: 14px;
+}
+
+.tracker-count {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0 0 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-light);
+}
+
+.tracker-count strong {
+  color: var(--text-dark);
+  font-weight: 600;
+}
+
+/* Per-item expand toggle */
+.tracker-toggle {
+  margin-top: 18px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--primary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.tracker-toggle:hover {
+  background: rgba(13, 79, 139, 0.06);
+  border-color: rgba(13, 79, 139, 0.3);
+}
+
+.tracker-toggle svg { transition: transform 0.2s ease; }
+.tracker-item.is-open .tracker-toggle svg { transform: rotate(180deg); }
+
+/* Stage history timeline */
+.tracker-history {
+  margin-top: 16px;
+  padding: 16px 18px;
+  background: var(--bg-card-alt);
+  border-radius: var(--radius-md);
+}
+
+.tracker-history ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+}
+
+.tracker-history li {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: 14px;
+  position: relative;
+  padding-bottom: 14px;
+}
+
+.tracker-history li:last-child { padding-bottom: 0; }
+
+.tracker-history li::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 14px;
+  bottom: 0;
+  width: 2px;
+  background: var(--border);
+}
+
+.tracker-history li:last-child::after { display: none; }
+
+.tracker-history-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--white);
+  border: 2px solid var(--primary);
+  margin-top: 3px;
+  z-index: 1;
+}
+
+.tracker-history-stage {
+  font-family: var(--font-display);
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+  margin-right: 10px;
+}
+
+.tracker-history-date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.tracker-history-note {
+  font-size: 0.88rem;
+  color: var(--text-body);
+  margin-top: 2px;
+  line-height: 1.5;
+}
+
+/* Kanban view */
+.tracker-kanban {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+@media (max-width: 980px) {
+  .tracker-kanban { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (max-width: 540px) {
+  .tracker-kanban { grid-template-columns: 1fr; }
+}
+
+.tracker-col {
+  background: var(--bg-card-alt);
+  border-radius: var(--radius-lg);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 140px;
+}
+
+.tracker-col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+}
+
+.tracker-col-title {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--primary-dark);
+}
+
+.tracker-col-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--white);
+  border: 1px solid var(--border);
+  color: var(--text-body);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.tracker-col-body {
+  display: grid;
+  gap: 10px;
+}
+
+.tracker-col-empty {
+  color: var(--text-light);
+  font-size: 13px;
+  text-align: center;
+  padding: 14px 0;
+  margin: 0;
+}
+
+.tracker-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+}
+
+.tracker-card:hover {
+  border-color: rgba(13, 79, 139, 0.28);
+  transform: translateY(-1px);
+}
+
+.tracker-card-head {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.tracker-card h4 {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+  line-height: 1.3;
+  margin: 4px 0 6px;
+}
+
+.tracker-card-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.tracker-card-date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-light);
+  margin: 6px 0 0;
 }
 
 .tracker-stages {

--- a/examples/css/examples.css
+++ b/examples/css/examples.css
@@ -1,0 +1,1016 @@
+/* ─────────────────────────────────────────────
+   VCASSE — Examples / New Features
+   Shared styling for the five proposed widgets.
+   Mirrors the design tokens used in dev/css/styles.css
+   so that the demos sit visually flush with the site.
+   ───────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@300;400;500;600;700;800;900&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&display=swap');
+
+:root {
+  --primary: #0d4f8b;
+  --primary-light: #1a6db5;
+  --primary-dark: #082a4d;
+  --ink-strong: #111827;
+  --ink-deep: #061833;
+  --slate-professional: #374151;
+  --secondary: #6b7280;
+  --bg-canvas: #ffffff;
+  --bg-light: #edf3f8;
+  --bg-page: #e2ecf4;
+  --bg-card: #ffffff;
+  --bg-card-alt: #f2f6fa;
+  --text-dark: #111827;
+  --text-body: #374151;
+  --text-muted: #6b7280;
+  --text-light: #9ca3af;
+  --white: #ffffff;
+  --green-accent: #6cb4e4;
+  --border: #e5e7eb;
+  --border-light: #f3f4f6;
+  --safety: #0d4f8b;
+  --sustainability: #1f8a6b;
+  --ethics: #8a4a8a;
+  --warning: #c2410c;
+  --success: #166534;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-xl: 12px;
+  --radius-2xl: 18px;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-md: 0 2px 8px rgba(0,0,0,0.06);
+  --shadow-lg: 0 4px 16px rgba(0,0,0,0.08);
+  --shadow-xl: 0 12px 32px rgba(8, 42, 77, 0.12);
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-display: 'IBM Plex Sans', var(--font-sans);
+  --font-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --font-serif: 'Newsreader', 'Source Serif Pro', Georgia, 'Times New Roman', serif;
+  --max-width: 1200px;
+  --nav-height: 64px;
+}
+
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+
+body {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text-body);
+  background: var(--bg-canvas);
+}
+
+a { color: inherit; text-decoration: none; transition: color 0.2s ease; }
+img { max-width: 100%; display: block; }
+button { font: inherit; cursor: pointer; }
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+/* ─────────────── Navigation ─────────────── */
+
+.examples-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(255,255,255,0.92);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  height: var(--nav-height);
+  display: flex;
+  align-items: center;
+}
+
+.examples-nav .container {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  width: 100%;
+}
+
+.examples-nav-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ink-strong);
+  letter-spacing: 0.1px;
+}
+
+.examples-nav-brand-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--primary-dark);
+  color: var(--white);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.examples-nav-tag {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--primary);
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(13, 79, 139, 0.08);
+}
+
+.examples-nav-back {
+  margin-left: auto;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-body);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.examples-nav-back:hover { color: var(--primary-dark); }
+
+/* ─────────────── Page hero ─────────────── */
+
+.example-hero {
+  padding: 64px 0 32px;
+  background: linear-gradient(180deg, var(--bg-light) 0%, var(--bg-canvas) 100%);
+}
+
+.example-hero .container { max-width: 880px; }
+
+.example-hero-kicker {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin-bottom: 14px;
+}
+
+.example-hero-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  line-height: 1.15;
+  font-weight: 600;
+  color: var(--ink-strong);
+  letter-spacing: -0.01em;
+  margin-bottom: 18px;
+}
+
+.example-hero-title em {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 400;
+  color: var(--primary);
+}
+
+.example-hero-lede {
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: var(--text-body);
+  max-width: 660px;
+}
+
+/* ─────────────── Section / panels ─────────────── */
+
+.example-section {
+  padding: 32px 0 80px;
+}
+
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2xl);
+  padding: 32px;
+  box-shadow: var(--shadow-md);
+}
+
+.panel-title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+  margin-bottom: 6px;
+}
+
+.panel-sub {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  margin-bottom: 22px;
+}
+
+/* ─────────────── Buttons ─────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+  padding: 12px 22px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--white);
+}
+
+.btn-primary:hover {
+  background: var(--primary-light);
+  border-color: var(--primary-light);
+  box-shadow: 0 8px 18px -8px rgba(13, 79, 139, 0.55);
+}
+
+.btn-primary:disabled {
+  background: var(--text-light);
+  border-color: var(--text-light);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-secondary {
+  background: var(--white);
+  border-color: var(--border);
+  color: var(--text-dark);
+}
+
+.btn-secondary:hover {
+  background: var(--bg-light);
+  border-color: rgba(8, 42, 77, 0.18);
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--primary);
+  padding: 8px 12px;
+}
+
+.btn-ghost:hover { color: var(--primary-dark); background: rgba(13, 79, 139, 0.06); }
+
+/* ─────────────── Pillar pills ─────────────── */
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bg-light);
+  color: var(--text-body);
+}
+
+.pill::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.pill--safety { color: var(--safety); background: rgba(13, 79, 139, 0.10); }
+.pill--sustainability { color: var(--sustainability); background: rgba(31, 138, 107, 0.10); }
+.pill--ethics { color: var(--ethics); background: rgba(138, 74, 138, 0.10); }
+.pill--all { color: var(--slate-professional); background: rgba(55, 65, 81, 0.08); }
+
+/* ─────────────── Feature index (landing) ─────────────── */
+
+.examples-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+  margin-top: 32px;
+}
+
+.example-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.example-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(13, 79, 139, 0.28);
+  box-shadow: var(--shadow-lg);
+}
+
+.example-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.example-card p {
+  font-size: 0.93rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.example-card-link {
+  margin-top: auto;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.example-card-link:hover { color: var(--primary-dark); }
+
+.example-card-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: rgba(13, 79, 139, 0.08);
+  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.example-card-icon svg { width: 20px; height: 20px; }
+
+/* ─────────────── Quiz ─────────────── */
+
+.quiz-card { max-width: 760px; margin: 0 auto; }
+
+.quiz-progress {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-bottom: 18px;
+}
+
+.quiz-progress-track {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-light);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.quiz-progress-fill {
+  height: 100%;
+  background: var(--primary);
+  width: 0%;
+  transition: width 0.4s ease;
+}
+
+.quiz-question {
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+  line-height: 1.35;
+  margin: 8px 0 22px;
+}
+
+.quiz-options {
+  display: grid;
+  gap: 10px;
+}
+
+.quiz-option {
+  text-align: left;
+  width: 100%;
+  background: var(--bg-card-alt);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 14px 18px;
+  font-size: 0.95rem;
+  color: var(--text-dark);
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.1s ease;
+}
+
+.quiz-option:hover { border-color: var(--primary-light); background: var(--white); }
+
+.quiz-option.is-selected { border-color: var(--primary); background: var(--white); }
+.quiz-option.is-correct { border-color: var(--success); background: rgba(22, 101, 52, 0.06); }
+.quiz-option.is-wrong { border-color: var(--warning); background: rgba(194, 65, 12, 0.05); }
+
+.quiz-feedback {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  font-size: 0.92rem;
+  background: var(--bg-light);
+  border-left: 3px solid var(--primary);
+  color: var(--text-body);
+}
+
+.quiz-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.quiz-result {
+  text-align: center;
+}
+
+.quiz-result-score {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--primary-dark);
+  letter-spacing: -0.02em;
+}
+
+.quiz-result-pillars {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  margin: 28px 0 12px;
+}
+
+.quiz-pillar-stat {
+  background: var(--bg-card-alt);
+  border-radius: var(--radius-lg);
+  padding: 14px;
+  text-align: center;
+}
+
+.quiz-pillar-stat-value {
+  font-family: var(--font-mono);
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.quiz-pillar-stat-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+@media (max-width: 600px) {
+  .quiz-result-pillars { grid-template-columns: 1fr; }
+}
+
+/* ─────────────── Carbon Calculator ─────────────── */
+
+.calc-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+@media (max-width: 880px) {
+  .calc-grid { grid-template-columns: 1fr; }
+}
+
+.calc-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.calc-input-group label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-dark);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.calc-input-group label .calc-value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.calc-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  background: var(--bg-light);
+  border-radius: 999px;
+  outline: none;
+}
+
+.calc-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--primary);
+  border: 2px solid var(--white);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+  cursor: pointer;
+}
+
+.calc-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--primary);
+  border: 2px solid var(--white);
+  cursor: pointer;
+}
+
+.calc-select {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--white);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  color: var(--text-dark);
+}
+
+.calc-results {
+  background: var(--primary-dark);
+  color: var(--white);
+  border-radius: var(--radius-2xl);
+  padding: 32px;
+  position: sticky;
+  top: 88px;
+}
+
+.calc-results-headline {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 6px;
+}
+
+.calc-results-number {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.calc-results-unit {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: rgba(255,255,255,0.7);
+  margin-top: 4px;
+}
+
+.calc-breakdown {
+  margin-top: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.calc-breakdown-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+  font-size: 0.92rem;
+}
+
+.calc-breakdown-row:last-child { border-bottom: none; }
+
+.calc-equiv {
+  margin-top: 22px;
+  padding: 14px 16px;
+  background: rgba(255,255,255,0.06);
+  border-radius: var(--radius-md);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: rgba(255,255,255,0.9);
+}
+
+.calc-equiv strong { color: var(--white); }
+
+/* ─────────────── Glossary ─────────────── */
+
+.glossary-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.glossary-search {
+  flex: 1;
+  min-width: 240px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--white);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  color: var(--text-dark);
+}
+
+.glossary-search:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(13, 79, 139, 0.12);
+}
+
+.glossary-filters {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.glossary-filter {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-body);
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.glossary-filter.is-active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--white);
+}
+
+.glossary-list {
+  display: grid;
+  gap: 14px;
+}
+
+.glossary-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 22px;
+  transition: border-color 0.2s ease, transform 0.15s ease;
+}
+
+.glossary-item:hover {
+  border-color: rgba(13, 79, 139, 0.25);
+  transform: translateY(-1px);
+}
+
+.glossary-item-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.glossary-term {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.glossary-def {
+  font-size: 0.93rem;
+  color: var(--text-body);
+  line-height: 1.6;
+}
+
+.glossary-empty {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* ─────────────── Policy Tracker ─────────────── */
+
+.tracker-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+@media (max-width: 720px) { .tracker-stats { grid-template-columns: repeat(2, 1fr); } }
+
+.tracker-stat {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+}
+
+.tracker-stat-value {
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--primary-dark);
+  line-height: 1;
+}
+
+.tracker-stat-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+
+.tracker-list {
+  display: grid;
+  gap: 14px;
+}
+
+.tracker-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 22px;
+}
+
+.tracker-item-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.tracker-item-title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.tracker-item-meta {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.tracker-item-blurb {
+  font-size: 0.93rem;
+  color: var(--text-body);
+  margin-bottom: 16px;
+}
+
+.tracker-stages {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  position: relative;
+}
+
+.tracker-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  position: relative;
+  padding-top: 18px;
+}
+
+.tracker-stage-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bg-light);
+  border: 2px solid var(--border);
+  z-index: 2;
+  position: relative;
+}
+
+/* Connector segment: drawn from the centre of this stage's dot to the
+   centre of the next stage's dot. Colour reflects whether THIS stage is
+   completed — i.e. progress has flowed past it. */
+.tracker-stage::before {
+  content: '';
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  width: 100%;
+  height: 2px;
+  background: var(--border);
+  z-index: 1;
+}
+
+.tracker-stage:last-child::before { display: none; }
+
+.tracker-stage.is-done .tracker-stage-dot {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.tracker-stage.is-done::before { background: var(--primary); }
+
+.tracker-stage.is-current .tracker-stage-dot {
+  background: var(--white);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(13, 79, 139, 0.18);
+}
+
+.tracker-stage-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.tracker-stage.is-done .tracker-stage-label,
+.tracker-stage.is-current .tracker-stage-label {
+  color: var(--primary-dark);
+}
+
+/* ─────────────── Question Wall ─────────────── */
+
+.qw-form {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.qw-form textarea {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  resize: vertical;
+  min-height: 96px;
+  color: var(--text-dark);
+}
+
+.qw-form textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(13, 79, 139, 0.12);
+}
+
+.qw-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.qw-form-pillars {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.qw-form-pillars button {
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-body);
+}
+
+.qw-form-pillars button.is-active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--white);
+}
+
+.qw-counter {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.qw-list {
+  display: grid;
+  gap: 14px;
+}
+
+.qw-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px 22px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: start;
+}
+
+.qw-vote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 52px;
+  background: var(--bg-card-alt);
+  border-radius: var(--radius-md);
+  padding: 10px 8px;
+}
+
+.qw-vote button {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  padding: 2px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.qw-vote button:hover { color: var(--primary); background: rgba(13, 79, 139, 0.08); }
+.qw-vote button.is-voted { color: var(--primary); }
+
+.qw-vote-count {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--ink-strong);
+}
+
+.qw-question {
+  font-size: 0.98rem;
+  color: var(--text-dark);
+  line-height: 1.55;
+  margin-bottom: 8px;
+}
+
+.qw-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.qw-empty {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  background: var(--bg-card-alt);
+  border-radius: var(--radius-lg);
+}
+
+/* ─────────────── Footer note ─────────────── */
+
+.example-footnote {
+  margin-top: 60px;
+  padding: 24px;
+  background: var(--bg-light);
+  border-radius: var(--radius-lg);
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  text-align: center;
+}
+
+.example-footnote strong { color: var(--text-dark); }

--- a/examples/glossary.html
+++ b/examples/glossary.html
@@ -28,9 +28,9 @@
       <p class="example-hero-kicker">Plain-Language AI Glossary</p>
       <h1 class="example-hero-title">A shared vocabulary for <em>responsible AI conversations.</em></h1>
       <p class="example-hero-lede">
-        Search the term you saw in the news. Filter by pillar. Each definition is
-        written in plain Vancouver English — short enough to drop into a council
-        meeting, accurate enough to stand up to a researcher.
+        Search the term you saw in the news. Filter by pillar or difficulty. Each definition
+        is written in plain Vancouver English — short enough to drop into a council meeting,
+        accurate enough to stand up to a researcher.
       </p>
     </div>
   </header>
@@ -39,17 +39,34 @@
     <div class="container">
       <section class="panel">
         <div class="glossary-controls">
-          <input type="search" id="glossary-search" class="glossary-search" placeholder="Search a term — e.g. ‘alignment’, ‘deepfake’, ‘inference’" aria-label="Search glossary">
-          <div class="glossary-filters" role="tablist">
+          <div class="glossary-search-wrap">
+            <svg class="glossary-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.3-4.3"/></svg>
+            <input type="search" id="glossary-search" class="glossary-search" placeholder="Search a term — e.g. 'alignment', 'deepfake', 'inference'" aria-label="Search glossary">
+            <kbd class="glossary-shortcut" aria-hidden="true">/</kbd>
+          </div>
+
+          <div class="glossary-filters" role="tablist" aria-label="Filter by pillar">
             <button class="glossary-filter is-active" data-pillar="all" type="button">All</button>
             <button class="glossary-filter" data-pillar="safety" type="button">Safety</button>
             <button class="glossary-filter" data-pillar="sustainability" type="button">Sustainability</button>
             <button class="glossary-filter" data-pillar="ethics" type="button">Ethics</button>
           </div>
+
+          <div class="glossary-filters" role="tablist" aria-label="Filter by level">
+            <button class="glossary-filter glossary-filter--level is-active" data-level="all" type="button">Any level</button>
+            <button class="glossary-filter glossary-filter--level" data-level="beginner" type="button">Beginner</button>
+            <button class="glossary-filter glossary-filter--level" data-level="intermediate" type="button">Intermediate</button>
+            <button class="glossary-filter glossary-filter--level" data-level="advanced" type="button">Advanced</button>
+          </div>
+        </div>
+
+        <div class="glossary-meta">
+          <p class="glossary-count" id="glossary-count">Showing all terms.</p>
+          <nav class="glossary-letters" id="glossary-letters" aria-label="Jump to letter"></nav>
         </div>
 
         <div class="glossary-list" id="glossary-list" aria-live="polite"></div>
-        <div class="glossary-empty" id="glossary-empty" hidden>No terms match. Try a shorter search.</div>
+        <div class="glossary-empty" id="glossary-empty" hidden>No terms match. Try a shorter search or clear the filters.</div>
       </section>
     </div>
   </main>

--- a/examples/glossary.html
+++ b/examples/glossary.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plain-Language AI Glossary — VCASSE</title>
+  <link rel="stylesheet" href="css/examples.css">
+  <link rel="icon" type="image/svg+xml" href="../dev/img/logo.svg">
+</head>
+<body>
+
+  <nav class="examples-nav">
+    <div class="container">
+      <a href="../dev/index.html" class="examples-nav-brand">
+        <span class="examples-nav-brand-mark">V</span>
+        <span>VCASSE</span>
+      </a>
+      <span class="examples-nav-tag">Widget · Literacy</span>
+      <a href="index.html" class="examples-nav-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        All widgets
+      </a>
+    </div>
+  </nav>
+
+  <header class="example-hero">
+    <div class="container">
+      <p class="example-hero-kicker">Plain-Language AI Glossary</p>
+      <h1 class="example-hero-title">A shared vocabulary for <em>responsible AI conversations.</em></h1>
+      <p class="example-hero-lede">
+        Search the term you saw in the news. Filter by pillar. Each definition is
+        written in plain Vancouver English — short enough to drop into a council
+        meeting, accurate enough to stand up to a researcher.
+      </p>
+    </div>
+  </header>
+
+  <main class="example-section">
+    <div class="container">
+      <section class="panel">
+        <div class="glossary-controls">
+          <input type="search" id="glossary-search" class="glossary-search" placeholder="Search a term — e.g. ‘alignment’, ‘deepfake’, ‘inference’" aria-label="Search glossary">
+          <div class="glossary-filters" role="tablist">
+            <button class="glossary-filter is-active" data-pillar="all" type="button">All</button>
+            <button class="glossary-filter" data-pillar="safety" type="button">Safety</button>
+            <button class="glossary-filter" data-pillar="sustainability" type="button">Sustainability</button>
+            <button class="glossary-filter" data-pillar="ethics" type="button">Ethics</button>
+          </div>
+        </div>
+
+        <div class="glossary-list" id="glossary-list" aria-live="polite"></div>
+        <div class="glossary-empty" id="glossary-empty" hidden>No terms match. Try a shorter search.</div>
+      </section>
+    </div>
+  </main>
+
+  <script src="js/glossary.js"></script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>New Features — VCASSE</title>
+  <link rel="stylesheet" href="css/examples.css">
+  <link rel="icon" type="image/svg+xml" href="../dev/img/logo.svg">
+</head>
+<body>
+
+  <nav class="examples-nav">
+    <div class="container">
+      <a href="../dev/index.html" class="examples-nav-brand">
+        <span class="examples-nav-brand-mark">V</span>
+        <span>VCASSE</span>
+      </a>
+      <span class="examples-nav-tag">Concept widgets</span>
+      <a href="../dev/index.html" class="examples-nav-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        Back to site
+      </a>
+    </div>
+  </nav>
+
+  <header class="example-hero">
+    <div class="container">
+      <p class="example-hero-kicker">Examples / Five proposed widgets</p>
+      <h1 class="example-hero-title">
+        Five new widgets to make VCASSE more <em>useful</em> to Vancouver.
+      </h1>
+      <p class="example-hero-lede">
+        Each demo below sketches a feature that fits VCASSE's mission: AI literacy,
+        sustainability accounting, ethical participation, and policy transparency.
+        These are working prototypes, not stubs — interact with them to see the
+        flow end to end.
+      </p>
+    </div>
+  </header>
+
+  <main class="example-section">
+    <div class="container">
+      <div class="examples-grid">
+
+        <a class="example-card" href="quiz.html">
+          <span class="example-card-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01"/></svg>
+          </span>
+          <h3>AI Literacy Quiz</h3>
+          <p>An eight-question primer across safety, sustainability, and ethics. Scores break down by pillar so visitors see where their understanding is strongest.</p>
+          <span class="example-card-link">Take the quiz →</span>
+        </a>
+
+        <a class="example-card" href="carbon-calculator.html">
+          <span class="example-card-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 12c0 5.5-9.5 9.5-9.5 9.5S2.5 17.5 2.5 12 7 2.5 12 2.5 21.5 6.5 21.5 12z"/><path d="M8 12c2 0 4-1.5 4-4M16 12c-2 0-4 1.5-4 4"/></svg>
+          </span>
+          <h3>AI Carbon Footprint Calculator</h3>
+          <p>Estimates the energy, water, and CO₂ cost of a visitor's AI usage habits, with everyday equivalents (kettle boils, kilometres driven) so the numbers land.</p>
+          <span class="example-card-link">Calculate impact →</span>
+        </a>
+
+        <a class="example-card" href="glossary.html">
+          <span class="example-card-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+          </span>
+          <h3>Plain-Language AI Glossary</h3>
+          <p>A search-as-you-type, pillar-filtered dictionary of AI terms. Aimed at residents, journalists, and policymakers who need a reliable shared vocabulary.</p>
+          <span class="example-card-link">Browse terms →</span>
+        </a>
+
+        <a class="example-card" href="policy-tracker.html">
+          <span class="example-card-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l3-9 4 18 3-9h4"/></svg>
+          </span>
+          <h3>Policy Brief Tracker</h3>
+          <p>A transparency widget showing every brief VCASSE has written, what stage it is at (Draft → Review → Submitted → Adopted), and which level of government it targets.</p>
+          <span class="example-card-link">View tracker →</span>
+        </a>
+
+        <a class="example-card" href="question-wall.html">
+          <span class="example-card-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          </span>
+          <h3>Community Question Wall</h3>
+          <p>Residents submit questions about AI ethics; others upvote what matters most. The top-voted questions become themes for upcoming public panels.</p>
+          <span class="example-card-link">Ask a question →</span>
+        </a>
+
+      </div>
+
+      <p class="example-footnote">
+        These prototypes live under <strong>/examples</strong> and use the same design tokens as the live site. They are intentionally
+        client-side only — no backend, no analytics — so they can be reviewed and merged feature-by-feature.
+      </p>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/examples/js/carbon-calculator.js
+++ b/examples/js/carbon-calculator.js
@@ -1,0 +1,98 @@
+(function () {
+  // Per-query energy estimates in watt-hours. These are illustrative figures
+  // sourced from public reporting on commercial AI inference; the calculator
+  // is meant to convey scale and tradeoffs, not to be a research instrument.
+  const PER_QUERY_WH = {
+    chat:  { small: 0.3,  mid: 1.0,  frontier: 3.0 },
+    long:  { small: 1.5,  mid: 5.0,  frontier: 15.0 },
+    image: { small: 1.0,  mid: 2.5,  frontier: 6.0 },
+  };
+
+  // Water (mL) consumed in cooling per Wh of inference, by grid scenario.
+  const WATER_ML_PER_WH = { bc: 0.05, us: 0.5, coal: 0.7 };
+
+  // gCO2e per Wh of electricity, by scenario.
+  const CO2_PER_WH = { bc: 0.05, us: 0.40, coal: 0.95 };
+
+  const DAYS_PER_WEEK = 7;
+
+  const inputs = {
+    chats:  document.getElementById('chats'),
+    long:   document.getElementById('long'),
+    images: document.getElementById('images'),
+    model:  document.getElementById('model'),
+    grid:   document.getElementById('grid'),
+  };
+
+  const outs = {
+    chats:  document.querySelector('[data-out="chats"]'),
+    long:   document.querySelector('[data-out="long"]'),
+    images: document.querySelector('[data-out="images"]'),
+    co2:    document.getElementById('co2-out'),
+    kwh:    document.getElementById('kwh-out'),
+    water:  document.getElementById('water-out'),
+    annual: document.getElementById('annual-out'),
+    equiv:  document.getElementById('equiv-out'),
+  };
+
+  function fmt(n, digits) {
+    if (!isFinite(n)) return '0';
+    if (n >= 1000) return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+    if (n >= 10) return n.toFixed(0);
+    if (n >= 1) return n.toFixed(1);
+    return n.toFixed(2);
+  }
+
+  function compute() {
+    const chats = +inputs.chats.value;
+    const longs = +inputs.long.value;
+    const images = +inputs.images.value;
+    const model = inputs.model.value;
+    const grid = inputs.grid.value;
+
+    outs.chats.textContent  = chats;
+    outs.long.textContent   = longs;
+    outs.images.textContent = images;
+
+    const dailyWh =
+      chats  * PER_QUERY_WH.chat[model] +
+      longs  * PER_QUERY_WH.long[model] +
+      images * PER_QUERY_WH.image[model];
+
+    const weeklyWh = dailyWh * DAYS_PER_WEEK;
+    const weeklyCO2 = weeklyWh * CO2_PER_WH[grid];   // grams
+    const weeklyWater = weeklyWh * WATER_ML_PER_WH[grid];
+    const annualKg = (weeklyCO2 * 52) / 1000;
+
+    outs.co2.textContent    = fmt(weeklyCO2);
+    outs.kwh.textContent    = fmt(weeklyWh);
+    outs.water.textContent  = fmt(weeklyWater);
+    outs.annual.textContent = fmt(annualKg);
+
+    outs.equiv.innerHTML = describeEquivalents(weeklyCO2, weeklyWater, weeklyWh);
+  }
+
+  function describeEquivalents(co2, waterMl, wh) {
+    if (co2 < 0.1) {
+      return "<strong>Effectively zero.</strong> Your weekly AI use is below the noise floor of common household activities.";
+    }
+    // Reference points (rounded for legibility):
+    //   Boiling 1L of water in a kettle ≈ 100 Wh
+    //   Driving 1 km in a typical car  ≈ 180 g CO₂
+    //   A standard cup of tap water    ≈ 250 mL
+    const kettles = wh / 100;
+    const km = co2 / 180;
+    const cups = waterMl / 250;
+
+    const parts = [];
+    if (kettles >= 0.1) parts.push(`<strong>${fmt(kettles)}</strong> kettles boiled`);
+    if (km >= 0.05)     parts.push(`<strong>${fmt(km)}</strong> km of car driving`);
+    if (cups >= 0.05)   parts.push(`<strong>${fmt(cups)}</strong> cups of cooling water`);
+
+    if (parts.length === 0) return "<strong>Roughly nothing.</strong> Below the threshold of common equivalents.";
+    return "Roughly equivalent each week to: " + parts.join(', ') + ".";
+  }
+
+  Object.values(inputs).forEach((el) => el.addEventListener('input', compute));
+  compute();
+})();

--- a/examples/js/carbon-calculator.js
+++ b/examples/js/carbon-calculator.js
@@ -1,25 +1,68 @@
 (function () {
-  // Per-query energy estimates in watt-hours. These are illustrative figures
-  // sourced from public reporting on commercial AI inference; the calculator
-  // is meant to convey scale and tradeoffs, not to be a research instrument.
-  const PER_QUERY_WH = {
-    chat:  { small: 0.3,  mid: 1.0,  frontier: 3.0 },
-    long:  { small: 1.5,  mid: 5.0,  frontier: 15.0 },
-    image: { small: 1.0,  mid: 2.5,  frontier: 6.0 },
+  // Per-query (or per-unit) inference energy in watt-hours, by model class.
+  // Illustrative figures from public reporting on commercial AI inference;
+  // intended to show scale, not to be a research instrument.
+  const PER_UNIT_WH = {
+    chat:  { small: 0.3,  mid: 1.0,  frontier: 3.0 },   // per message
+    long:  { small: 1.5,  mid: 5.0,  frontier: 15.0 },  // per long-form generation
+    code:  { small: 0.2,  mid: 0.6,  frontier: 1.8 },   // per completion
+    image: { small: 1.0,  mid: 2.5,  frontier: 6.0 },   // per image
+    voice: { small: 0.05, mid: 0.15, frontier: 0.4 },   // per minute of audio
+    video: { small: 30,   mid: 80,   frontier: 200 },   // per short clip
+  };
+
+  const ACTIVITY_LABEL = {
+    chat: 'Chat',
+    long: 'Long-form',
+    code: 'Code',
+    image: 'Images',
+    voice: 'Voice',
+    video: 'Video',
+  };
+
+  const ACTIVITY_COLOR = {
+    chat:  '#1a6db5',
+    long:  '#0d4f8b',
+    code:  '#1f8a6b',
+    image: '#8a4a8a',
+    voice: '#c2410c',
+    video: '#374151',
   };
 
   // Water (mL) consumed in cooling per Wh of inference, by grid scenario.
   const WATER_ML_PER_WH = { bc: 0.05, us: 0.5, coal: 0.7 };
-
   // gCO2e per Wh of electricity, by scenario.
-  const CO2_PER_WH = { bc: 0.05, us: 0.40, coal: 0.95 };
+  const CO2_PER_WH      = { bc: 0.05, us: 0.40, coal: 0.95 };
 
   const DAYS_PER_WEEK = 7;
+
+  // Rough Vancouver-resident benchmark in gCO2e/week. Tunable.
+  const VANCOUVER_AVG_WEEKLY_CO2 = 35;
+
+  // Categories with their daily/weekly cadence (video is a weekly slider).
+  const CATEGORIES = [
+    { key: 'chat',  cadence: 'daily',  inputId: 'chats'  },
+    { key: 'long',  cadence: 'daily',  inputId: 'long'   },
+    { key: 'code',  cadence: 'daily',  inputId: 'code'   },
+    { key: 'image', cadence: 'daily',  inputId: 'images' },
+    { key: 'voice', cadence: 'daily',  inputId: 'voice'  },
+    { key: 'video', cadence: 'weekly', inputId: 'video'  },
+  ];
+
+  const PRESETS = {
+    light:   { chats: 5,   long: 1,  code: 0,   images: 0, voice: 0,  video: 0, model: 'small',    grid: 'bc' },
+    typical: { chats: 20,  long: 3,  code: 15,  images: 2, voice: 0,  video: 0, model: 'mid',      grid: 'bc' },
+    heavy:   { chats: 60,  long: 10, code: 80,  images: 6, voice: 15, video: 1, model: 'mid',      grid: 'us' },
+    power:   { chats: 150, long: 25, code: 250, images: 20,voice: 60, video: 5, model: 'frontier', grid: 'us' },
+  };
 
   const inputs = {
     chats:  document.getElementById('chats'),
     long:   document.getElementById('long'),
+    code:   document.getElementById('code'),
     images: document.getElementById('images'),
+    voice:  document.getElementById('voice'),
+    video:  document.getElementById('video'),
     model:  document.getElementById('model'),
     grid:   document.getElementById('grid'),
   };
@@ -27,15 +70,24 @@
   const outs = {
     chats:  document.querySelector('[data-out="chats"]'),
     long:   document.querySelector('[data-out="long"]'),
+    code:   document.querySelector('[data-out="code"]'),
     images: document.querySelector('[data-out="images"]'),
+    voice:  document.querySelector('[data-out="voice"]'),
+    video:  document.querySelector('[data-out="video"]'),
     co2:    document.getElementById('co2-out'),
     kwh:    document.getElementById('kwh-out'),
     water:  document.getElementById('water-out'),
     annual: document.getElementById('annual-out'),
     equiv:  document.getElementById('equiv-out'),
+    bench:  document.getElementById('bench-out'),
+    bar:    document.getElementById('attr-bar'),
+    legend: document.getElementById('attr-legend'),
+    tips:   document.getElementById('tips-out'),
   };
 
-  function fmt(n, digits) {
+  const presetBtns = document.querySelectorAll('.calc-preset');
+
+  function fmt(n) {
     if (!isFinite(n)) return '0';
     if (n >= 1000) return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
     if (n >= 10) return n.toFixed(0);
@@ -44,32 +96,62 @@
   }
 
   function compute() {
-    const chats = +inputs.chats.value;
-    const longs = +inputs.long.value;
-    const images = +inputs.images.value;
     const model = inputs.model.value;
     const grid = inputs.grid.value;
 
-    outs.chats.textContent  = chats;
-    outs.long.textContent   = longs;
-    outs.images.textContent = images;
+    // Reflect raw inputs into their counters.
+    ['chats', 'long', 'code', 'images', 'voice', 'video'].forEach((k) => {
+      outs[k].textContent = inputs[k].value;
+    });
 
-    const dailyWh =
-      chats  * PER_QUERY_WH.chat[model] +
-      longs  * PER_QUERY_WH.long[model] +
-      images * PER_QUERY_WH.image[model];
+    // Per-activity Wh per week.
+    const perActivityWh = {};
+    CATEGORIES.forEach(({ key, cadence, inputId }) => {
+      const count = +inputs[inputId].value;
+      const wh = count * PER_UNIT_WH[key][model] * (cadence === 'daily' ? DAYS_PER_WEEK : 1);
+      perActivityWh[key] = wh;
+    });
 
-    const weeklyWh = dailyWh * DAYS_PER_WEEK;
-    const weeklyCO2 = weeklyWh * CO2_PER_WH[grid];   // grams
+    const weeklyWh = Object.values(perActivityWh).reduce((a, b) => a + b, 0);
+    const weeklyCO2   = weeklyWh * CO2_PER_WH[grid];
     const weeklyWater = weeklyWh * WATER_ML_PER_WH[grid];
-    const annualKg = (weeklyCO2 * 52) / 1000;
+    const annualKg    = (weeklyCO2 * 52) / 1000;
 
     outs.co2.textContent    = fmt(weeklyCO2);
     outs.kwh.textContent    = fmt(weeklyWh);
     outs.water.textContent  = fmt(weeklyWater);
     outs.annual.textContent = fmt(annualKg);
 
+    renderAttribution(perActivityWh, weeklyWh);
     outs.equiv.innerHTML = describeEquivalents(weeklyCO2, weeklyWater, weeklyWh);
+    outs.bench.innerHTML = describeBenchmark(weeklyCO2);
+    outs.tips.innerHTML  = renderTips(perActivityWh, weeklyWh, model, grid);
+  }
+
+  function renderAttribution(perActivityWh, total) {
+    if (total <= 0) {
+      outs.bar.innerHTML = '<span class="calc-attr-empty">No usage entered yet — try a preset.</span>';
+      outs.legend.innerHTML = '';
+      return;
+    }
+
+    const ranked = Object.entries(perActivityWh)
+      .filter(([, wh]) => wh > 0)
+      .sort((a, b) => b[1] - a[1]);
+
+    outs.bar.innerHTML = ranked.map(([key, wh]) => {
+      const pct = (wh / total) * 100;
+      return `<span class="calc-attr-seg" style="width:${pct}%;background:${ACTIVITY_COLOR[key]};" title="${ACTIVITY_LABEL[key]} — ${pct.toFixed(0)}%"></span>`;
+    }).join('');
+
+    outs.legend.innerHTML = ranked.map(([key, wh]) => {
+      const pct = (wh / total) * 100;
+      return `<li>
+        <span class="calc-attr-swatch" style="background:${ACTIVITY_COLOR[key]};"></span>
+        <span>${ACTIVITY_LABEL[key]}</span>
+        <span class="calc-attr-pct">${pct.toFixed(0)}%</span>
+      </li>`;
+    }).join('');
   }
 
   function describeEquivalents(co2, waterMl, wh) {
@@ -78,8 +160,8 @@
     }
     // Reference points (rounded for legibility):
     //   Boiling 1L of water in a kettle ≈ 100 Wh
-    //   Driving 1 km in a typical car  ≈ 180 g CO₂
-    //   A standard cup of tap water    ≈ 250 mL
+    //   Driving 1 km in a typical car   ≈ 180 g CO₂
+    //   A standard cup of tap water     ≈ 250 mL
     const kettles = wh / 100;
     const km = co2 / 180;
     const cups = waterMl / 250;
@@ -93,6 +175,62 @@
     return "Roughly equivalent each week to: " + parts.join(', ') + ".";
   }
 
-  Object.values(inputs).forEach((el) => el.addEventListener('input', compute));
+  function describeBenchmark(co2) {
+    if (co2 <= 0) return '';
+    const ratio = co2 / VANCOUVER_AVG_WEEKLY_CO2;
+    let label, tone;
+    if (ratio < 0.5)      { label = `${(ratio * 100).toFixed(0)}% of a typical Vancouverite's AI footprint`; tone = 'low'; }
+    else if (ratio < 1.5) { label = 'about average for a Vancouver resident'; tone = 'mid'; }
+    else if (ratio < 3)   { label = `${ratio.toFixed(1)}× the typical Vancouverite`; tone = 'high'; }
+    else                  { label = `${ratio.toFixed(0)}× the typical Vancouverite`; tone = 'high'; }
+
+    return `<span class="calc-bench-pill calc-bench--${tone}">${label}</span>`;
+  }
+
+  function renderTips(perActivityWh, total, model, grid) {
+    if (total <= 0) return '';
+    const ranked = Object.entries(perActivityWh).filter(([, w]) => w > 0).sort((a, b) => b[1] - a[1]);
+    const top = ranked[0] && ranked[0][0];
+    const tips = [];
+
+    if (model === 'frontier') {
+      tips.push(`Switch the <strong>default model class</strong> to mid-size for routine work — frontier models cost roughly 3× the energy per query.`);
+    }
+    if (grid !== 'bc') {
+      tips.push(`Where possible, choose providers that run on <strong>low-carbon grids</strong>. The same query can cost 8–19× more CO₂ on a coal-heavy grid than on BC hydro.`);
+    }
+    if (top === 'video') {
+      tips.push(`Video generation is your top contributor. Each clip can equal hundreds of chat messages — only generate when you'd otherwise commission a video.`);
+    } else if (top === 'image') {
+      tips.push(`Image generation dominates your week. Reuse outputs and avoid 'regenerate' loops — each retry has the same cost as the first.`);
+    } else if (top === 'long') {
+      tips.push(`Long-form generations are your biggest line item. Shorter, more iterative prompts often beat one giant request and use far less compute.`);
+    } else if (top === 'code') {
+      tips.push(`Code completions are dominating. Limit autocomplete to files you're actively editing rather than triggering it on every keystroke.`);
+    } else if (top === 'voice') {
+      tips.push(`Voice is your top contributor. Batch transcriptions instead of running them in real time when latency doesn't matter.`);
+    } else if (top === 'chat') {
+      tips.push(`Most of your footprint is short chats. Caching frequent questions or using a smaller model for them is the single highest-leverage change you can make.`);
+    }
+
+    if (tips.length === 0) return '';
+    return `<p class="calc-tips-title">How to lower this</p><ul class="calc-tips-list">${tips.map(t => `<li>${t}</li>`).join('')}</ul>`;
+  }
+
+  function applyPreset(name) {
+    const p = PRESETS[name];
+    if (!p) return;
+    Object.keys(p).forEach((k) => { if (inputs[k]) inputs[k].value = p[k]; });
+    presetBtns.forEach((b) => b.classList.toggle('is-active', b.dataset.preset === name));
+    compute();
+  }
+
+  presetBtns.forEach((btn) => btn.addEventListener('click', () => applyPreset(btn.dataset.preset)));
+
+  Object.values(inputs).forEach((el) => el.addEventListener('input', () => {
+    presetBtns.forEach((b) => b.classList.remove('is-active'));
+    compute();
+  }));
+
   compute();
 })();

--- a/examples/js/glossary.js
+++ b/examples/js/glossary.js
@@ -1,0 +1,166 @@
+(function () {
+  const TERMS = [
+    {
+      term: "Alignment",
+      pillar: "safety",
+      def: "The problem of getting an AI system to actually pursue the goals its operators intended, even in situations the designers didn't anticipate."
+    },
+    {
+      term: "Algorithmic bias",
+      pillar: "ethics",
+      def: "Systematic, repeatable error in an AI system that produces unfair outcomes for some groups — usually traceable to training data, modelling choices, or deployment context."
+    },
+    {
+      term: "Audit (AI audit)",
+      pillar: "ethics",
+      def: "An independent examination of an AI system to check whether it does what it claims, who it works for, and who it leaves behind."
+    },
+    {
+      term: "Carbon-aware computing",
+      pillar: "sustainability",
+      def: "Scheduling AI workloads — especially training — for times and regions when the local grid is greener, e.g. when hydro or wind output is high."
+    },
+    {
+      term: "Compute",
+      pillar: "sustainability",
+      def: "The processing power needed to train or run an AI model. Usually measured in GPU-hours and translated into electricity and cooling water at the data centre."
+    },
+    {
+      term: "Deepfake",
+      pillar: "ethics",
+      def: "Synthetic media — usually images, video, or audio — that depicts a real person doing or saying something they did not. A core ethics concern around consent, fraud, and democratic integrity."
+    },
+    {
+      term: "Disclosure",
+      pillar: "ethics",
+      def: "Telling people that AI is being used in a decision or service that affects them, in language they can understand and act on."
+    },
+    {
+      term: "Evaluation (eval)",
+      pillar: "safety",
+      def: "A structured test that probes an AI system for unsafe or unintended behaviour before deployment — for example, testing whether a model can be jailbroken into giving hazardous instructions."
+    },
+    {
+      term: "Foundation model",
+      pillar: "safety",
+      def: "A large general-purpose AI model trained on broad data, intended to be adapted to many downstream tasks. Most current commercial chat models are foundation models."
+    },
+    {
+      term: "Hallucination",
+      pillar: "safety",
+      def: "When a language model produces text that sounds confident but is factually wrong or fabricated. Mitigated, not eliminated, by techniques like retrieval and citations."
+    },
+    {
+      term: "Inference",
+      pillar: "sustainability",
+      def: "Running a trained model in production to answer a query. For widely deployed models, total inference energy can dwarf the cost of original training."
+    },
+    {
+      term: "Jailbreak",
+      pillar: "safety",
+      def: "A prompt or technique that gets a deployed AI system to bypass its safety guardrails. A common target of red-team evaluations."
+    },
+    {
+      term: "Model card",
+      pillar: "ethics",
+      def: "A short structured document that ships with a model describing its intended use, known limitations, training data sources, and evaluation results."
+    },
+    {
+      term: "Procurement (responsible AI procurement)",
+      pillar: "ethics",
+      def: "The discipline of buying AI systems for an organisation in a way that bakes in safety, sustainability, and ethics requirements before the contract is signed."
+    },
+    {
+      term: "Red team",
+      pillar: "safety",
+      def: "A team whose explicit job is to attack an AI system — find jailbreaks, biases, and failure modes — so that defenders can fix them before launch."
+    },
+    {
+      term: "Retrieval-Augmented Generation (RAG)",
+      pillar: "safety",
+      def: "A technique where a language model looks up relevant documents at query time and grounds its answer in them, reducing hallucinations."
+    },
+    {
+      term: "Right-sizing",
+      pillar: "sustainability",
+      def: "Choosing the smallest model that does the job well. Often the highest-leverage way to cut the energy and cost of an AI deployment."
+    },
+    {
+      term: "Training",
+      pillar: "sustainability",
+      def: "The (usually one-time, expensive) process of teaching a model from data. Frontier-model training is dominated by electricity and cooling water at the data-centre level."
+    },
+    {
+      term: "Watermarking",
+      pillar: "ethics",
+      def: "Embedding a hidden signal in AI-generated content so it can later be identified as machine-made. An active and contested area of policy."
+    },
+    {
+      term: "Weight (model weight)",
+      pillar: "safety",
+      def: "The learned numerical parameters that make a model do what it does. Releasing model weights changes the security and safety calculus dramatically."
+    },
+  ];
+
+  const PILLAR_LABEL = { safety: 'Safety', sustainability: 'Sustainability', ethics: 'Ethics' };
+
+  const listEl = document.getElementById('glossary-list');
+  const emptyEl = document.getElementById('glossary-empty');
+  const searchEl = document.getElementById('glossary-search');
+  const filters = document.querySelectorAll('.glossary-filter');
+
+  const state = { query: '', pillar: 'all' };
+
+  function render() {
+    const q = state.query.trim().toLowerCase();
+    const items = TERMS
+      .filter((t) => state.pillar === 'all' || t.pillar === state.pillar)
+      .filter((t) => !q || t.term.toLowerCase().includes(q) || t.def.toLowerCase().includes(q))
+      .sort((a, b) => a.term.localeCompare(b.term));
+
+    if (items.length === 0) {
+      listEl.innerHTML = '';
+      emptyEl.hidden = false;
+      return;
+    }
+    emptyEl.hidden = true;
+
+    listEl.innerHTML = items.map((t) => `
+      <article class="glossary-item">
+        <div class="glossary-item-header">
+          <span class="glossary-term">${escapeHtml(t.term)}</span>
+          <span class="pill pill--${t.pillar}">${PILLAR_LABEL[t.pillar]}</span>
+        </div>
+        <p class="glossary-def">${highlight(escapeHtml(t.def), q)}</p>
+      </article>
+    `).join('');
+  }
+
+  function escapeHtml(s) {
+    return s.replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+  }
+
+  function highlight(text, q) {
+    if (!q) return text;
+    const re = new RegExp('(' + q.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + ')', 'ig');
+    return text.replace(re, '<mark style="background:#fff3cd;color:inherit;border-radius:3px;padding:0 2px;">$1</mark>');
+  }
+
+  searchEl.addEventListener('input', (e) => {
+    state.query = e.target.value;
+    render();
+  });
+
+  filters.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      filters.forEach((b) => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      state.pillar = btn.dataset.pillar;
+      render();
+    });
+  });
+
+  render();
+})();

--- a/examples/js/glossary.js
+++ b/examples/js/glossary.js
@@ -1,140 +1,180 @@
 (function () {
   const TERMS = [
     {
+      id: 'alignment',
       term: "Alignment",
       pillar: "safety",
-      def: "The problem of getting an AI system to actually pursue the goals its operators intended, even in situations the designers didn't anticipate."
+      level: "intermediate",
+      def: "The problem of getting an AI system to actually pursue the goals its operators intended, even in situations the designers didn't anticipate.",
+      seeAlso: ['evaluation', 'red-team']
     },
     {
+      id: 'algorithmic-bias',
       term: "Algorithmic bias",
       pillar: "ethics",
-      def: "Systematic, repeatable error in an AI system that produces unfair outcomes for some groups — usually traceable to training data, modelling choices, or deployment context."
+      level: "beginner",
+      def: "Systematic, repeatable error in an AI system that produces unfair outcomes for some groups — usually traceable to training data, modelling choices, or deployment context.",
+      seeAlso: ['audit', 'model-card']
     },
     {
+      id: 'audit',
       term: "Audit (AI audit)",
       pillar: "ethics",
-      def: "An independent examination of an AI system to check whether it does what it claims, who it works for, and who it leaves behind."
+      level: "intermediate",
+      def: "An independent examination of an AI system to check whether it does what it claims, who it works for, and who it leaves behind.",
+      seeAlso: ['algorithmic-bias', 'evaluation']
     },
     {
+      id: 'carbon-aware',
       term: "Carbon-aware computing",
       pillar: "sustainability",
-      def: "Scheduling AI workloads — especially training — for times and regions when the local grid is greener, e.g. when hydro or wind output is high."
+      level: "intermediate",
+      def: "Scheduling AI workloads — especially training — for times and regions when the local grid is greener, e.g. when hydro or wind output is high.",
+      seeAlso: ['compute', 'right-sizing']
     },
     {
+      id: 'compute',
       term: "Compute",
       pillar: "sustainability",
-      def: "The processing power needed to train or run an AI model. Usually measured in GPU-hours and translated into electricity and cooling water at the data centre."
+      level: "beginner",
+      def: "The processing power needed to train or run an AI model. Usually measured in GPU-hours and translated into electricity and cooling water at the data centre.",
+      seeAlso: ['training', 'inference']
     },
     {
+      id: 'deepfake',
       term: "Deepfake",
       pillar: "ethics",
-      def: "Synthetic media — usually images, video, or audio — that depicts a real person doing or saying something they did not. A core ethics concern around consent, fraud, and democratic integrity."
+      level: "beginner",
+      def: "Synthetic media — usually images, video, or audio — that depicts a real person doing or saying something they did not. A core ethics concern around consent, fraud, and democratic integrity.",
+      seeAlso: ['watermarking', 'disclosure']
     },
     {
+      id: 'disclosure',
       term: "Disclosure",
       pillar: "ethics",
-      def: "Telling people that AI is being used in a decision or service that affects them, in language they can understand and act on."
+      level: "beginner",
+      def: "Telling people that AI is being used in a decision or service that affects them, in language they can understand and act on.",
+      seeAlso: ['procurement', 'audit']
     },
     {
+      id: 'evaluation',
       term: "Evaluation (eval)",
       pillar: "safety",
-      def: "A structured test that probes an AI system for unsafe or unintended behaviour before deployment — for example, testing whether a model can be jailbroken into giving hazardous instructions."
+      level: "intermediate",
+      def: "A structured test that probes an AI system for unsafe or unintended behaviour before deployment — for example, testing whether a model can be jailbroken into giving hazardous instructions.",
+      seeAlso: ['red-team', 'jailbreak', 'alignment']
     },
     {
+      id: 'foundation-model',
       term: "Foundation model",
       pillar: "safety",
-      def: "A large general-purpose AI model trained on broad data, intended to be adapted to many downstream tasks. Most current commercial chat models are foundation models."
+      level: "intermediate",
+      def: "A large general-purpose AI model trained on broad data, intended to be adapted to many downstream tasks. Most current commercial chat models are foundation models.",
+      seeAlso: ['weight', 'training']
     },
     {
+      id: 'hallucination',
       term: "Hallucination",
       pillar: "safety",
-      def: "When a language model produces text that sounds confident but is factually wrong or fabricated. Mitigated, not eliminated, by techniques like retrieval and citations."
+      level: "beginner",
+      def: "When a language model produces text that sounds confident but is factually wrong or fabricated. Mitigated, not eliminated, by techniques like retrieval and citations.",
+      seeAlso: ['rag', 'evaluation']
     },
     {
+      id: 'inference',
       term: "Inference",
       pillar: "sustainability",
-      def: "Running a trained model in production to answer a query. For widely deployed models, total inference energy can dwarf the cost of original training."
+      level: "beginner",
+      def: "Running a trained model in production to answer a query. For widely deployed models, total inference energy can dwarf the cost of original training.",
+      seeAlso: ['training', 'compute', 'right-sizing']
     },
     {
+      id: 'jailbreak',
       term: "Jailbreak",
       pillar: "safety",
-      def: "A prompt or technique that gets a deployed AI system to bypass its safety guardrails. A common target of red-team evaluations."
+      level: "beginner",
+      def: "A prompt or technique that gets a deployed AI system to bypass its safety guardrails. A common target of red-team evaluations.",
+      seeAlso: ['red-team', 'evaluation']
     },
     {
+      id: 'model-card',
       term: "Model card",
       pillar: "ethics",
-      def: "A short structured document that ships with a model describing its intended use, known limitations, training data sources, and evaluation results."
+      level: "intermediate",
+      def: "A short structured document that ships with a model describing its intended use, known limitations, training data sources, and evaluation results.",
+      seeAlso: ['disclosure', 'audit']
     },
     {
+      id: 'procurement',
       term: "Procurement (responsible AI procurement)",
       pillar: "ethics",
-      def: "The discipline of buying AI systems for an organisation in a way that bakes in safety, sustainability, and ethics requirements before the contract is signed."
+      level: "advanced",
+      def: "The discipline of buying AI systems for an organisation in a way that bakes in safety, sustainability, and ethics requirements before the contract is signed.",
+      seeAlso: ['disclosure', 'audit', 'model-card']
     },
     {
+      id: 'red-team',
       term: "Red team",
       pillar: "safety",
-      def: "A team whose explicit job is to attack an AI system — find jailbreaks, biases, and failure modes — so that defenders can fix them before launch."
+      level: "intermediate",
+      def: "A team whose explicit job is to attack an AI system — find jailbreaks, biases, and failure modes — so that defenders can fix them before launch.",
+      seeAlso: ['jailbreak', 'evaluation']
     },
     {
+      id: 'rag',
       term: "Retrieval-Augmented Generation (RAG)",
       pillar: "safety",
-      def: "A technique where a language model looks up relevant documents at query time and grounds its answer in them, reducing hallucinations."
+      level: "advanced",
+      def: "A technique where a language model looks up relevant documents at query time and grounds its answer in them, reducing hallucinations.",
+      seeAlso: ['hallucination', 'inference']
     },
     {
+      id: 'right-sizing',
       term: "Right-sizing",
       pillar: "sustainability",
-      def: "Choosing the smallest model that does the job well. Often the highest-leverage way to cut the energy and cost of an AI deployment."
+      level: "intermediate",
+      def: "Choosing the smallest model that does the job well. Often the highest-leverage way to cut the energy and cost of an AI deployment.",
+      seeAlso: ['inference', 'compute', 'carbon-aware']
     },
     {
+      id: 'training',
       term: "Training",
       pillar: "sustainability",
-      def: "The (usually one-time, expensive) process of teaching a model from data. Frontier-model training is dominated by electricity and cooling water at the data-centre level."
+      level: "beginner",
+      def: "The (usually one-time, expensive) process of teaching a model from data. Frontier-model training is dominated by electricity and cooling water at the data-centre level.",
+      seeAlso: ['inference', 'compute']
     },
     {
+      id: 'watermarking',
       term: "Watermarking",
       pillar: "ethics",
-      def: "Embedding a hidden signal in AI-generated content so it can later be identified as machine-made. An active and contested area of policy."
+      level: "advanced",
+      def: "Embedding a hidden signal in AI-generated content so it can later be identified as machine-made. An active and contested area of policy.",
+      seeAlso: ['deepfake', 'disclosure']
     },
     {
+      id: 'weight',
       term: "Weight (model weight)",
       pillar: "safety",
-      def: "The learned numerical parameters that make a model do what it does. Releasing model weights changes the security and safety calculus dramatically."
+      level: "advanced",
+      def: "The learned numerical parameters that make a model do what it does. Releasing model weights changes the security and safety calculus dramatically.",
+      seeAlso: ['foundation-model', 'training']
     },
   ];
 
+  const TERM_BY_ID = Object.fromEntries(TERMS.map(t => [t.id, t]));
   const PILLAR_LABEL = { safety: 'Safety', sustainability: 'Sustainability', ethics: 'Ethics' };
+  const LEVEL_LABEL = { beginner: 'Beginner', intermediate: 'Intermediate', advanced: 'Advanced' };
 
   const listEl = document.getElementById('glossary-list');
   const emptyEl = document.getElementById('glossary-empty');
   const searchEl = document.getElementById('glossary-search');
-  const filters = document.querySelectorAll('.glossary-filter');
+  const countEl = document.getElementById('glossary-count');
+  const lettersEl = document.getElementById('glossary-letters');
+  const pillarFilters = document.querySelectorAll('.glossary-filter:not(.glossary-filter--level)');
+  const levelFilters = document.querySelectorAll('.glossary-filter--level');
 
-  const state = { query: '', pillar: 'all' };
-
-  function render() {
-    const q = state.query.trim().toLowerCase();
-    const items = TERMS
-      .filter((t) => state.pillar === 'all' || t.pillar === state.pillar)
-      .filter((t) => !q || t.term.toLowerCase().includes(q) || t.def.toLowerCase().includes(q))
-      .sort((a, b) => a.term.localeCompare(b.term));
-
-    if (items.length === 0) {
-      listEl.innerHTML = '';
-      emptyEl.hidden = false;
-      return;
-    }
-    emptyEl.hidden = true;
-
-    listEl.innerHTML = items.map((t) => `
-      <article class="glossary-item">
-        <div class="glossary-item-header">
-          <span class="glossary-term">${escapeHtml(t.term)}</span>
-          <span class="pill pill--${t.pillar}">${PILLAR_LABEL[t.pillar]}</span>
-        </div>
-        <p class="glossary-def">${highlight(escapeHtml(t.def), q)}</p>
-      </article>
-    `).join('');
-  }
+  const state = { query: '', pillar: 'all', level: 'all' };
 
   function escapeHtml(s) {
     return s.replace(/[&<>"']/g, (c) => ({
@@ -145,21 +185,157 @@
   function highlight(text, q) {
     if (!q) return text;
     const re = new RegExp('(' + q.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + ')', 'ig');
-    return text.replace(re, '<mark style="background:#fff3cd;color:inherit;border-radius:3px;padding:0 2px;">$1</mark>');
+    return text.replace(re, '<mark>$1</mark>');
   }
+
+  function renderLetters(items) {
+    const present = new Set(items.map(t => t.term[0].toUpperCase()));
+    const all = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    lettersEl.innerHTML = all.split('').map(L => {
+      const has = present.has(L);
+      return `<button type="button" class="glossary-letter ${has ? '' : 'is-disabled'}" data-letter="${L}" ${has ? '' : 'disabled aria-disabled="true"'}>${L}</button>`;
+    }).join('');
+  }
+
+  function render() {
+    const q = state.query.trim().toLowerCase();
+    const items = TERMS
+      .filter((t) => state.pillar === 'all' || t.pillar === state.pillar)
+      .filter((t) => state.level === 'all' || t.level === state.level)
+      .filter((t) => !q || t.term.toLowerCase().includes(q) || t.def.toLowerCase().includes(q))
+      .sort((a, b) => a.term.localeCompare(b.term));
+
+    const total = TERMS.length;
+    countEl.innerHTML = items.length === total
+      ? `Showing all <strong>${total}</strong> terms.`
+      : `Showing <strong>${items.length}</strong> of <strong>${total}</strong> terms.`;
+
+    renderLetters(items);
+
+    if (items.length === 0) {
+      listEl.innerHTML = '';
+      emptyEl.hidden = false;
+      return;
+    }
+    emptyEl.hidden = true;
+
+    listEl.innerHTML = items.map((t) => {
+      const seeAlso = (t.seeAlso || [])
+        .map(id => TERM_BY_ID[id])
+        .filter(Boolean)
+        .map(ref => `<a class="glossary-xref" href="#${ref.id}" data-jump="${ref.id}">${escapeHtml(ref.term.split(' (')[0])}</a>`)
+        .join(' · ');
+
+      return `
+        <article class="glossary-item" id="${t.id}" data-letter="${t.term[0].toUpperCase()}">
+          <div class="glossary-item-header">
+            <a class="glossary-term" href="#${t.id}" data-copy="${t.id}" title="Copy link to this term">${escapeHtml(t.term)}</a>
+            <span class="pill pill--${t.pillar}">${PILLAR_LABEL[t.pillar]}</span>
+            <span class="glossary-level glossary-level--${t.level}">${LEVEL_LABEL[t.level]}</span>
+          </div>
+          <p class="glossary-def">${highlight(escapeHtml(t.def), q)}</p>
+          ${seeAlso ? `<p class="glossary-seealso"><span>See also:</span> ${seeAlso}</p>` : ''}
+        </article>
+      `;
+    }).join('');
+
+    // Cross-reference jumping (animated highlight on the target).
+    listEl.querySelectorAll('[data-jump]').forEach((a) => {
+      a.addEventListener('click', (e) => {
+        const id = a.dataset.jump;
+        const target = document.getElementById(id);
+        if (!target) return;
+        e.preventDefault();
+        history.replaceState(null, '', '#' + id);
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        target.classList.remove('is-flash');
+        // Force reflow so the animation can re-trigger.
+        void target.offsetWidth;
+        target.classList.add('is-flash');
+      });
+    });
+
+    // Click on the term heading copies a deep link.
+    listEl.querySelectorAll('[data-copy]').forEach((a) => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const id = a.dataset.copy;
+        const url = location.origin + location.pathname + '#' + id;
+        history.replaceState(null, '', '#' + id);
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(url).then(() => flashCopied(a)).catch(() => {});
+        }
+      });
+    });
+
+    // Initial deep-link target — flash highlight if URL has a hash.
+    if (location.hash) {
+      const target = document.getElementById(location.hash.slice(1));
+      if (target) {
+        target.classList.add('is-flash');
+        target.scrollIntoView({ behavior: 'auto', block: 'center' });
+      }
+    }
+  }
+
+  function flashCopied(a) {
+    const prev = a.getAttribute('data-prev-text') || a.textContent;
+    a.setAttribute('data-prev-text', prev);
+    a.classList.add('is-copied');
+    a.textContent = 'Link copied ✓';
+    setTimeout(() => {
+      a.classList.remove('is-copied');
+      a.textContent = prev;
+      a.removeAttribute('data-prev-text');
+    }, 1300);
+  }
+
+  // Letter index click → scroll to first term starting with that letter.
+  lettersEl.addEventListener('click', (e) => {
+    const btn = e.target.closest('.glossary-letter');
+    if (!btn || btn.disabled) return;
+    const L = btn.dataset.letter;
+    const target = listEl.querySelector(`.glossary-item[data-letter="${L}"]`);
+    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
 
   searchEl.addEventListener('input', (e) => {
     state.query = e.target.value;
     render();
   });
 
-  filters.forEach((btn) => {
+  pillarFilters.forEach((btn) => {
     btn.addEventListener('click', () => {
-      filters.forEach((b) => b.classList.remove('is-active'));
+      pillarFilters.forEach((b) => b.classList.remove('is-active'));
       btn.classList.add('is-active');
       state.pillar = btn.dataset.pillar;
       render();
     });
+  });
+
+  levelFilters.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      levelFilters.forEach((b) => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      state.level = btn.dataset.level;
+      render();
+    });
+  });
+
+  // Keyboard: '/' to focus search, Esc to clear.
+  document.addEventListener('keydown', (e) => {
+    const tag = (e.target.tagName || '').toLowerCase();
+    const typing = tag === 'input' || tag === 'textarea' || e.target.isContentEditable;
+    if (e.key === '/' && !typing) {
+      e.preventDefault();
+      searchEl.focus();
+      searchEl.select();
+    } else if (e.key === 'Escape' && document.activeElement === searchEl) {
+      searchEl.value = '';
+      state.query = '';
+      render();
+      searchEl.blur();
+    }
   });
 
   render();

--- a/examples/js/policy-tracker.js
+++ b/examples/js/policy-tracker.js
@@ -1,0 +1,149 @@
+(function () {
+  const STAGES = ['Draft', 'Internal review', 'Submitted', 'Adopted / cited'];
+
+  const BRIEFS = [
+    {
+      title: "Procurement standards for municipal AI tools",
+      pillar: "ethics",
+      target: "City of Vancouver — Procurement",
+      stage: 3,
+      blurb: "Recommended disclosure, contestability, and bias-evaluation clauses for any AI system the City buys.",
+      updated: "2026-03-02",
+    },
+    {
+      title: "Pre-deployment evaluation checklist for civic chatbots",
+      pillar: "safety",
+      target: "City of Vancouver — Service Innovation",
+      stage: 2,
+      blurb: "A short, audit-friendly checklist of safety evals to run before a 311-style chatbot goes live.",
+      updated: "2026-03-29",
+    },
+    {
+      title: "Reporting standards for AI water and energy use",
+      pillar: "sustainability",
+      target: "Province of BC — Climate Action Secretariat",
+      stage: 2,
+      blurb: "What AI vendors operating in BC should disclose about training and inference resource use.",
+      updated: "2026-04-08",
+    },
+    {
+      title: "Plain-language disclosure rules for synthetic media",
+      pillar: "ethics",
+      target: "Federal — Heritage Canada",
+      stage: 1,
+      blurb: "When AI-generated content is shown to residents, what must be disclosed and how.",
+      updated: "2026-04-14",
+    },
+    {
+      title: "Right-sizing guidance for public sector AI deployments",
+      pillar: "sustainability",
+      target: "City of Vancouver — IT",
+      stage: 1,
+      blurb: "When to choose a small distilled model over a frontier model — with worked examples.",
+      updated: "2026-04-18",
+    },
+    {
+      title: "Incident reporting for harms from AI in services",
+      pillar: "safety",
+      target: "Provincial — Office of the Ombudsperson",
+      stage: 0,
+      blurb: "A draft reporting flow for when AI-driven decisions produce a harmful outcome for a resident.",
+      updated: "2026-04-22",
+    },
+    {
+      title: "Worker consultation requirements for AI-driven scheduling",
+      pillar: "ethics",
+      target: "Provincial — Labour",
+      stage: 0,
+      blurb: "Frontline workers should be consulted before AI-driven scheduling tools are introduced.",
+      updated: "2026-04-23",
+    },
+  ];
+
+  const PILLAR_LABEL = { safety: 'Safety', sustainability: 'Sustainability', ethics: 'Ethics' };
+
+  const listEl = document.getElementById('tracker-list');
+  const statsEl = document.getElementById('tracker-stats');
+  const filters = document.querySelectorAll('#tracker-filters .glossary-filter');
+
+  const state = { pillar: 'all' };
+
+  function renderStats() {
+    const total = BRIEFS.length;
+    const adopted = BRIEFS.filter((b) => b.stage === 3).length;
+    const submitted = BRIEFS.filter((b) => b.stage >= 2).length;
+    const inProgress = BRIEFS.filter((b) => b.stage < 2).length;
+
+    statsEl.innerHTML = `
+      <div class="tracker-stat">
+        <div class="tracker-stat-value">${total}</div>
+        <div class="tracker-stat-label">Total briefs</div>
+      </div>
+      <div class="tracker-stat">
+        <div class="tracker-stat-value">${inProgress}</div>
+        <div class="tracker-stat-label">In progress</div>
+      </div>
+      <div class="tracker-stat">
+        <div class="tracker-stat-value">${submitted}</div>
+        <div class="tracker-stat-label">Submitted+</div>
+      </div>
+      <div class="tracker-stat">
+        <div class="tracker-stat-value">${adopted}</div>
+        <div class="tracker-stat-label">Adopted / cited</div>
+      </div>
+    `;
+  }
+
+  function renderList() {
+    const items = BRIEFS
+      .filter((b) => state.pillar === 'all' || b.pillar === state.pillar)
+      .sort((a, b) => new Date(b.updated) - new Date(a.updated));
+
+    if (items.length === 0) {
+      listEl.innerHTML = `<div class="qw-empty">No briefs in this pillar yet.</div>`;
+      return;
+    }
+
+    listEl.innerHTML = items.map((b) => `
+      <article class="tracker-item">
+        <div class="tracker-item-head">
+          <span class="pill pill--${b.pillar}">${PILLAR_LABEL[b.pillar]}</span>
+          <h3 class="tracker-item-title">${escapeHtml(b.title)}</h3>
+          <span class="tracker-item-meta">Updated ${formatDate(b.updated)}</span>
+        </div>
+        <p class="tracker-item-blurb">${escapeHtml(b.blurb)} <span style="color:var(--text-muted);">— ${escapeHtml(b.target)}</span></p>
+        <div class="tracker-stages" role="list" aria-label="Brief progress">
+          ${STAGES.map((label, i) => `
+            <div class="tracker-stage ${i < b.stage ? 'is-done' : ''} ${i === b.stage ? 'is-current' : ''}" role="listitem">
+              <span class="tracker-stage-dot"></span>
+              <span class="tracker-stage-label">${label}</span>
+            </div>
+          `).join('')}
+        </div>
+      </article>
+    `).join('');
+  }
+
+  function escapeHtml(s) {
+    return s.replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+  }
+
+  function formatDate(iso) {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  filters.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      filters.forEach((b) => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      state.pillar = btn.dataset.pillar;
+      renderList();
+    });
+  });
+
+  renderStats();
+  renderList();
+})();

--- a/examples/js/policy-tracker.js
+++ b/examples/js/policy-tracker.js
@@ -1,72 +1,176 @@
 (function () {
   const STAGES = ['Draft', 'Internal review', 'Submitted', 'Adopted / cited'];
+  const GOV_LABEL = { city: 'City', province: 'Province', federal: 'Federal' };
 
+  // Each brief includes a `history` of stage transitions with dates so the
+  // tracker can show *when* a brief moved through each step — not just where
+  // it currently sits.
   const BRIEFS = [
     {
       title: "Procurement standards for municipal AI tools",
       pillar: "ethics",
+      gov: "city",
       target: "City of Vancouver — Procurement",
+      lead: "Priya Sandhu",
       stage: 3,
       blurb: "Recommended disclosure, contestability, and bias-evaluation clauses for any AI system the City buys.",
       updated: "2026-03-02",
+      history: [
+        { stage: 0, date: "2025-09-14", note: "Initial draft circulated internally." },
+        { stage: 1, date: "2025-10-22", note: "Internal review with two external reviewers." },
+        { stage: 2, date: "2025-12-01", note: "Submitted to City Procurement Office." },
+        { stage: 3, date: "2026-03-02", note: "Cited in updated procurement guidelines (s.4.2)." },
+      ],
     },
     {
       title: "Pre-deployment evaluation checklist for civic chatbots",
       pillar: "safety",
+      gov: "city",
       target: "City of Vancouver — Service Innovation",
+      lead: "Dr. Mei Tanaka",
       stage: 2,
       blurb: "A short, audit-friendly checklist of safety evals to run before a 311-style chatbot goes live.",
       updated: "2026-03-29",
+      history: [
+        { stage: 0, date: "2026-01-08", note: "Drafted alongside Service Innovation team." },
+        { stage: 1, date: "2026-02-12", note: "Reviewed by VCASSE safety pillar." },
+        { stage: 2, date: "2026-03-29", note: "Submitted; awaiting council response." },
+      ],
     },
     {
       title: "Reporting standards for AI water and energy use",
       pillar: "sustainability",
+      gov: "province",
       target: "Province of BC — Climate Action Secretariat",
+      lead: "Dr. Aria Lin",
       stage: 2,
       blurb: "What AI vendors operating in BC should disclose about training and inference resource use.",
       updated: "2026-04-08",
+      history: [
+        { stage: 0, date: "2025-11-10", note: "Drafted with sustainability working group." },
+        { stage: 1, date: "2026-01-30", note: "External review with two grid researchers." },
+        { stage: 2, date: "2026-04-08", note: "Submitted to Secretariat." },
+      ],
     },
     {
       title: "Plain-language disclosure rules for synthetic media",
       pillar: "ethics",
+      gov: "federal",
       target: "Federal — Heritage Canada",
+      lead: "Jonas Beaumont",
       stage: 1,
       blurb: "When AI-generated content is shown to residents, what must be disclosed and how.",
       updated: "2026-04-14",
+      history: [
+        { stage: 0, date: "2026-02-20", note: "Drafted." },
+        { stage: 1, date: "2026-04-14", note: "In internal review." },
+      ],
     },
     {
       title: "Right-sizing guidance for public sector AI deployments",
       pillar: "sustainability",
+      gov: "city",
       target: "City of Vancouver — IT",
+      lead: "Dr. Aria Lin",
       stage: 1,
       blurb: "When to choose a small distilled model over a frontier model — with worked examples.",
       updated: "2026-04-18",
+      history: [
+        { stage: 0, date: "2026-03-04", note: "Drafted with municipal IT contacts." },
+        { stage: 1, date: "2026-04-18", note: "In internal review." },
+      ],
     },
     {
       title: "Incident reporting for harms from AI in services",
       pillar: "safety",
+      gov: "province",
       target: "Provincial — Office of the Ombudsperson",
+      lead: "Priya Sandhu",
       stage: 0,
       blurb: "A draft reporting flow for when AI-driven decisions produce a harmful outcome for a resident.",
       updated: "2026-04-22",
+      history: [
+        { stage: 0, date: "2026-04-22", note: "Initial draft started." },
+      ],
     },
     {
       title: "Worker consultation requirements for AI-driven scheduling",
       pillar: "ethics",
+      gov: "province",
       target: "Provincial — Labour",
+      lead: "Jonas Beaumont",
       stage: 0,
       blurb: "Frontline workers should be consulted before AI-driven scheduling tools are introduced.",
       updated: "2026-04-23",
+      history: [
+        { stage: 0, date: "2026-04-23", note: "Initial draft underway." },
+      ],
     },
   ];
 
   const PILLAR_LABEL = { safety: 'Safety', sustainability: 'Sustainability', ethics: 'Ethics' };
 
   const listEl = document.getElementById('tracker-list');
+  const kanbanEl = document.getElementById('tracker-kanban');
+  const emptyEl = document.getElementById('tracker-empty');
   const statsEl = document.getElementById('tracker-stats');
-  const filters = document.querySelectorAll('#tracker-filters .glossary-filter');
+  const countEl = document.getElementById('tracker-count');
+  const searchEl = document.getElementById('tracker-search');
+  const sortEl = document.getElementById('tracker-sort');
+  const viewBtns = document.querySelectorAll('.tracker-view-toggle button');
+  const pillarBtns = document.querySelectorAll('.tracker-filters [data-pillar]');
+  const govBtns = document.querySelectorAll('.tracker-filters [data-gov]');
 
-  const state = { pillar: 'all' };
+  const state = {
+    pillar: 'all',
+    gov: 'all',
+    query: '',
+    sort: 'recent',
+    view: 'list',
+    expanded: new Set(),
+  };
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+  }
+
+  function formatDate(iso) {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  function briefId(b) {
+    return 'b-' + b.title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  }
+
+  function filtered() {
+    const q = state.query.trim().toLowerCase();
+    return BRIEFS.filter((b) => state.pillar === 'all' || b.pillar === state.pillar)
+      .filter((b) => state.gov === 'all' || b.gov === state.gov)
+      .filter((b) => {
+        if (!q) return true;
+        return b.title.toLowerCase().includes(q)
+          || b.target.toLowerCase().includes(q)
+          || (b.lead || '').toLowerCase().includes(q)
+          || b.blurb.toLowerCase().includes(q);
+      });
+  }
+
+  function sorted(items) {
+    const arr = [...items];
+    switch (state.sort) {
+      case 'oldest':    arr.sort((a, b) => new Date(a.updated) - new Date(b.updated)); break;
+      case 'stage-desc':arr.sort((a, b) => b.stage - a.stage || new Date(b.updated) - new Date(a.updated)); break;
+      case 'stage-asc': arr.sort((a, b) => a.stage - b.stage || new Date(b.updated) - new Date(a.updated)); break;
+      case 'title':     arr.sort((a, b) => a.title.localeCompare(b.title)); break;
+      case 'recent':
+      default:          arr.sort((a, b) => new Date(b.updated) - new Date(a.updated));
+    }
+    return arr;
+  }
 
   function renderStats() {
     const total = BRIEFS.length;
@@ -94,24 +198,22 @@
     `;
   }
 
-  function renderList() {
-    const items = BRIEFS
-      .filter((b) => state.pillar === 'all' || b.pillar === state.pillar)
-      .sort((a, b) => new Date(b.updated) - new Date(a.updated));
+  function renderItem(b) {
+    const id = briefId(b);
+    const isOpen = state.expanded.has(id);
 
-    if (items.length === 0) {
-      listEl.innerHTML = `<div class="qw-empty">No briefs in this pillar yet.</div>`;
-      return;
-    }
-
-    listEl.innerHTML = items.map((b) => `
-      <article class="tracker-item">
+    return `
+      <article class="tracker-item ${isOpen ? 'is-open' : ''}" data-id="${id}">
         <div class="tracker-item-head">
           <span class="pill pill--${b.pillar}">${PILLAR_LABEL[b.pillar]}</span>
+          <span class="pill pill--all">${GOV_LABEL[b.gov]}</span>
           <h3 class="tracker-item-title">${escapeHtml(b.title)}</h3>
           <span class="tracker-item-meta">Updated ${formatDate(b.updated)}</span>
         </div>
-        <p class="tracker-item-blurb">${escapeHtml(b.blurb)} <span style="color:var(--text-muted);">— ${escapeHtml(b.target)}</span></p>
+        <p class="tracker-item-blurb">
+          ${escapeHtml(b.blurb)}
+          <span class="tracker-item-target">— ${escapeHtml(b.target)} · Lead: ${escapeHtml(b.lead || 'TBD')}</span>
+        </p>
         <div class="tracker-stages" role="list" aria-label="Brief progress">
           ${STAGES.map((label, i) => `
             <div class="tracker-stage ${i < b.stage ? 'is-done' : ''} ${i === b.stage ? 'is-current' : ''}" role="listitem">
@@ -120,26 +222,127 @@
             </div>
           `).join('')}
         </div>
+        <button type="button" class="tracker-toggle" data-toggle="${id}" aria-expanded="${isOpen}">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+          ${isOpen ? 'Hide' : 'Show'} stage history
+        </button>
+        <div class="tracker-history" ${isOpen ? '' : 'hidden'}>
+          <ol>
+            ${(b.history || []).map((h) => `
+              <li>
+                <span class="tracker-history-dot"></span>
+                <div>
+                  <span class="tracker-history-stage">${STAGES[h.stage]}</span>
+                  <span class="tracker-history-date">${formatDate(h.date)}</span>
+                  <p class="tracker-history-note">${escapeHtml(h.note)}</p>
+                </div>
+              </li>
+            `).join('')}
+          </ol>
+        </div>
       </article>
-    `).join('');
+    `;
   }
 
-  function escapeHtml(s) {
-    return s.replace(/[&<>"']/g, (c) => ({
-      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-    }[c]));
+  function renderList() {
+    const items = sorted(filtered());
+
+    countEl.innerHTML = items.length === BRIEFS.length
+      ? `Showing all <strong>${BRIEFS.length}</strong> briefs.`
+      : `Showing <strong>${items.length}</strong> of <strong>${BRIEFS.length}</strong> briefs.`;
+
+    if (items.length === 0) {
+      listEl.hidden = true;
+      kanbanEl.hidden = true;
+      emptyEl.hidden = false;
+      return;
+    }
+    emptyEl.hidden = true;
+
+    if (state.view === 'list') {
+      listEl.hidden = false;
+      kanbanEl.hidden = true;
+      listEl.innerHTML = items.map(renderItem).join('');
+      bindListInteractions();
+    } else {
+      listEl.hidden = true;
+      kanbanEl.hidden = false;
+      kanbanEl.innerHTML = STAGES.map((label, i) => {
+        const col = items.filter((b) => b.stage === i);
+        return `
+          <section class="tracker-col" aria-label="${label}">
+            <header class="tracker-col-head">
+              <span class="tracker-col-title">${label}</span>
+              <span class="tracker-col-count">${col.length}</span>
+            </header>
+            <div class="tracker-col-body">
+              ${col.length === 0
+                ? `<p class="tracker-col-empty">—</p>`
+                : col.map((b) => `
+                    <article class="tracker-card">
+                      <div class="tracker-card-head">
+                        <span class="pill pill--${b.pillar}">${PILLAR_LABEL[b.pillar]}</span>
+                        <span class="pill pill--all">${GOV_LABEL[b.gov]}</span>
+                      </div>
+                      <h4>${escapeHtml(b.title)}</h4>
+                      <p class="tracker-card-meta">${escapeHtml(b.target)}</p>
+                      <p class="tracker-card-meta">Lead: ${escapeHtml(b.lead || 'TBD')}</p>
+                      <p class="tracker-card-date">Updated ${formatDate(b.updated)}</p>
+                    </article>
+                  `).join('')
+              }
+            </div>
+          </section>
+        `;
+      }).join('');
+    }
   }
 
-  function formatDate(iso) {
-    const d = new Date(iso);
-    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  function bindListInteractions() {
+    listEl.querySelectorAll('[data-toggle]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.toggle;
+        if (state.expanded.has(id)) state.expanded.delete(id);
+        else state.expanded.add(id);
+        renderList();
+      });
+    });
   }
 
-  filters.forEach((btn) => {
+  searchEl.addEventListener('input', (e) => {
+    state.query = e.target.value;
+    renderList();
+  });
+
+  sortEl.addEventListener('change', (e) => {
+    state.sort = e.target.value;
+    renderList();
+  });
+
+  viewBtns.forEach((btn) => {
     btn.addEventListener('click', () => {
-      filters.forEach((b) => b.classList.remove('is-active'));
+      viewBtns.forEach((b) => { b.classList.remove('is-active'); b.setAttribute('aria-pressed', 'false'); });
+      btn.classList.add('is-active');
+      btn.setAttribute('aria-pressed', 'true');
+      state.view = btn.dataset.view;
+      renderList();
+    });
+  });
+
+  pillarBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      pillarBtns.forEach((b) => b.classList.remove('is-active'));
       btn.classList.add('is-active');
       state.pillar = btn.dataset.pillar;
+      renderList();
+    });
+  });
+
+  govBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      govBtns.forEach((b) => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      state.gov = btn.dataset.gov;
       renderList();
     });
   });

--- a/examples/js/question-wall.js
+++ b/examples/js/question-wall.js
@@ -1,0 +1,183 @@
+(function () {
+  const STORAGE_KEY = 'vcasse_question_wall_v1';
+  const VOTED_KEY = 'vcasse_question_wall_voted_v1';
+  const PILLAR_LABEL = { safety: 'Safety', sustainability: 'Sustainability', ethics: 'Ethics' };
+
+  const SEEDED = [
+    {
+      id: 'q-1',
+      text: "Should the City of Vancouver be required to publish a list of every AI system it uses in resident-facing services?",
+      pillar: "ethics",
+      votes: 47,
+      created: "2026-04-12",
+    },
+    {
+      id: 'q-2',
+      text: "What's a fair way to charge AI providers for the BC water and electricity their data centres use?",
+      pillar: "sustainability",
+      votes: 38,
+      created: "2026-04-08",
+    },
+    {
+      id: 'q-3',
+      text: "If an AI tool denies someone a service, who is responsible — the vendor, the City, or the manager who approved it?",
+      pillar: "ethics",
+      votes: 35,
+      created: "2026-04-15",
+    },
+    {
+      id: 'q-4',
+      text: "How do we evaluate whether a chatbot deployed by a public agency is actually safe for vulnerable users?",
+      pillar: "safety",
+      votes: 28,
+      created: "2026-04-19",
+    },
+    {
+      id: 'q-5',
+      text: "Should AI-generated content in political advertising have to be labelled in BC?",
+      pillar: "ethics",
+      votes: 22,
+      created: "2026-04-22",
+    },
+  ];
+
+  const form = document.getElementById('qw-form');
+  const textEl = document.getElementById('qw-text');
+  const counterEl = document.getElementById('qw-counter');
+  const listEl = document.getElementById('qw-list');
+  const pillarBtns = document.querySelectorAll('.qw-form-pillars button');
+
+  let selectedPillar = 'ethics';
+
+  function load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [...SEEDED];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [...SEEDED];
+      return parsed;
+    } catch {
+      return [...SEEDED];
+    }
+  }
+
+  function save(qs) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(qs)); } catch { /* noop */ }
+  }
+
+  function loadVoted() {
+    try {
+      const raw = localStorage.getItem(VOTED_KEY);
+      return new Set(raw ? JSON.parse(raw) : []);
+    } catch {
+      return new Set();
+    }
+  }
+
+  function saveVoted(set) {
+    try { localStorage.setItem(VOTED_KEY, JSON.stringify([...set])); } catch { /* noop */ }
+  }
+
+  let questions = load();
+  let voted = loadVoted();
+
+  function escapeHtml(s) {
+    return s.replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+  }
+
+  function formatDate(iso) {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  function render() {
+    if (questions.length === 0) {
+      listEl.innerHTML = `<div class="qw-empty">No questions yet. Be the first to ask.</div>`;
+      return;
+    }
+
+    const sorted = [...questions].sort((a, b) => b.votes - a.votes);
+
+    listEl.innerHTML = sorted.map((q) => {
+      const isVoted = voted.has(q.id);
+      return `
+        <article class="qw-item" data-id="${q.id}">
+          <div class="qw-vote">
+            <button type="button" class="qw-upvote ${isVoted ? 'is-voted' : ''}" aria-pressed="${isVoted}" aria-label="Upvote question">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5l7 7H5z"/></svg>
+            </button>
+            <span class="qw-vote-count">${q.votes}</span>
+          </div>
+          <div>
+            <p class="qw-question">${escapeHtml(q.text)}</p>
+            <div class="qw-meta">
+              <span class="pill pill--${q.pillar}">${PILLAR_LABEL[q.pillar]}</span>
+              <span>${formatDate(q.created)}</span>
+            </div>
+          </div>
+        </article>
+      `;
+    }).join('');
+
+    listEl.querySelectorAll('.qw-item').forEach((el) => {
+      const id = el.dataset.id;
+      const btn = el.querySelector('.qw-upvote');
+      btn.addEventListener('click', () => toggleVote(id));
+    });
+  }
+
+  function toggleVote(id) {
+    const q = questions.find((x) => x.id === id);
+    if (!q) return;
+
+    if (voted.has(id)) {
+      voted.delete(id);
+      q.votes = Math.max(0, q.votes - 1);
+    } else {
+      voted.add(id);
+      q.votes += 1;
+    }
+    save(questions);
+    saveVoted(voted);
+    render();
+  }
+
+  pillarBtns.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      pillarBtns.forEach((b) => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      selectedPillar = btn.dataset.pillar;
+    });
+  });
+
+  textEl.addEventListener('input', () => {
+    counterEl.textContent = `${textEl.value.length} / 240`;
+  });
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const text = textEl.value.trim();
+    if (text.length < 8) return;
+
+    const id = 'q-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
+    questions.push({
+      id,
+      text,
+      pillar: selectedPillar,
+      votes: 1,
+      created: new Date().toISOString().slice(0, 10),
+    });
+    voted.add(id);
+    save(questions);
+    saveVoted(voted);
+
+    textEl.value = '';
+    counterEl.textContent = '0 / 240';
+    render();
+  });
+
+  render();
+})();

--- a/examples/js/quiz.js
+++ b/examples/js/quiz.js
@@ -1,0 +1,220 @@
+(function () {
+  const QUESTIONS = [
+    {
+      pillar: 'safety',
+      question: "What is an 'AI evaluation' in the safety sense?",
+      options: [
+        "A performance benchmark for new GPUs.",
+        "A structured test that probes a model for unsafe or unintended behaviour before deployment.",
+        "A user satisfaction survey collected after launch.",
+        "A code review of the training pipeline."
+      ],
+      correct: 1,
+      explain: "Safety evaluations are pre-deployment tests that surface failure modes — like jailbreaks, biased outputs, or hazardous instructions — so they can be mitigated before users are affected."
+    },
+    {
+      pillar: 'safety',
+      question: "Which of these is closest to the AI safety idea of 'alignment'?",
+      options: [
+        "Making sure the model's outputs match the goals and values its operators intended.",
+        "Aligning the model's training data against a fixed schema.",
+        "Centring the chat window on the page.",
+        "Quantising weights for efficient inference."
+      ],
+      correct: 0,
+      explain: "Alignment is the problem of getting an AI system to actually pursue the goals we want, including in situations its designers did not anticipate."
+    },
+    {
+      pillar: 'safety',
+      question: "If a deployed model starts producing harmful outputs, what is usually the first responsible step?",
+      options: [
+        "Wait and see if users complain.",
+        "Quietly retrain on the affected prompts.",
+        "Roll back or gate the feature, then investigate root cause and disclose appropriately.",
+        "Blame the user for prompt engineering."
+      ],
+      correct: 2,
+      explain: "Incident response in AI safety mirrors security incident response: contain the impact, investigate, and be transparent with affected stakeholders."
+    },
+    {
+      pillar: 'sustainability',
+      question: "Roughly, what is the dominant resource cost of training a frontier-scale language model?",
+      options: [
+        "Paper and printer toner in the office.",
+        "Electricity for compute and cooling, with associated water for data-centre cooling.",
+        "Bandwidth for downloading training data.",
+        "Carbon offsets purchased afterwards."
+      ],
+      correct: 1,
+      explain: "Frontier model training is dominated by electricity and cooling water use at the data-centre level. Reporting both is becoming a baseline expectation for responsible AI labs."
+    },
+    {
+      pillar: 'sustainability',
+      question: "Why might 'inference' (running a model in production) matter more than training over a model's lifetime?",
+      options: [
+        "Because training only happens once.",
+        "Because inference happens billions of times across users, and small per-call costs add up.",
+        "Because models forget their training without inference.",
+        "Inference is always cheaper than training, so it doesn't matter."
+      ],
+      correct: 1,
+      explain: "Training is large but bounded; inference is small per call but runs at scale. For widely deployed models, total inference energy can dwarf the training cost."
+    },
+    {
+      pillar: 'sustainability',
+      question: "Which of these is a credible way to reduce the environmental cost of using AI?",
+      options: [
+        "Always pick the largest model available.",
+        "Match model size to the task — use smaller distilled models when they suffice.",
+        "Run inference twice to double-check answers.",
+        "Disable caching to keep results fresh."
+      ],
+      correct: 1,
+      explain: "Right-sizing models is one of the highest-leverage levers. A well-chosen 8B model often matches a 70B model on narrow tasks at a fraction of the energy."
+    },
+    {
+      pillar: 'ethics',
+      question: "What does 'algorithmic bias' typically refer to?",
+      options: [
+        "A preference one engineer has for Python over Rust.",
+        "Systematic, repeatable error in an AI system that produces unfair outcomes for some groups.",
+        "A floating-point rounding error.",
+        "An advertising preference set by the user."
+      ],
+      correct: 1,
+      explain: "Algorithmic bias is structural: it flows from training data, modelling choices, and deployment context, and it lands hardest on groups that were under-represented or mis-represented in those steps."
+    },
+    {
+      pillar: 'ethics',
+      question: "A city is buying an AI system to triage 311 service requests. Which question matters MOST from an ethics standpoint?",
+      options: [
+        "Does the vendor's logo look professional?",
+        "Will residents and frontline workers be told the system is in use, and can decisions be appealed?",
+        "Is it the cheapest option?",
+        "Does it use the latest model version?"
+      ],
+      correct: 1,
+      explain: "Disclosure and contestability — knowing AI is involved and being able to challenge an outcome — are core procurement-ethics questions for civic AI."
+    }
+  ];
+
+  const PILLAR_LABEL = { safety: 'Safety', sustainability: 'Sustainability', ethics: 'Ethics' };
+
+  const root = document.getElementById('quiz-root');
+  const state = {
+    index: 0,
+    selected: null,
+    answers: [],
+  };
+
+  function render() {
+    if (state.index >= QUESTIONS.length) return renderResult();
+    const q = QUESTIONS[state.index];
+    const pct = Math.round((state.index / QUESTIONS.length) * 100);
+
+    root.innerHTML = `
+      <div class="quiz-progress">
+        <span>Question ${state.index + 1} of ${QUESTIONS.length}</span>
+        <span class="quiz-progress-track"><span class="quiz-progress-fill" style="width:${pct}%"></span></span>
+        <span class="pill pill--${q.pillar}">${PILLAR_LABEL[q.pillar]}</span>
+      </div>
+      <h2 class="quiz-question">${q.question}</h2>
+      <div class="quiz-options" role="radiogroup" aria-label="Answer choices">
+        ${q.options.map((opt, i) => `
+          <button type="button" class="quiz-option" data-i="${i}" role="radio" aria-checked="false">${opt}</button>
+        `).join('')}
+      </div>
+      <div class="quiz-feedback" id="quiz-feedback" hidden></div>
+      <div class="quiz-controls">
+        <button type="button" class="btn btn-primary" id="quiz-next" disabled>
+          ${state.index === QUESTIONS.length - 1 ? 'See results' : 'Next question'}
+        </button>
+        <span style="color:var(--text-muted);font-size:13px;">Pick the option that best matches what VCASSE would teach.</span>
+      </div>
+    `;
+
+    root.querySelectorAll('.quiz-option').forEach((btn) => {
+      btn.addEventListener('click', () => onSelect(parseInt(btn.dataset.i, 10)));
+    });
+    root.querySelector('#quiz-next').addEventListener('click', onNext);
+  }
+
+  function onSelect(i) {
+    const q = QUESTIONS[state.index];
+    state.selected = i;
+
+    root.querySelectorAll('.quiz-option').forEach((btn) => {
+      const idx = parseInt(btn.dataset.i, 10);
+      btn.classList.remove('is-selected', 'is-correct', 'is-wrong');
+      btn.setAttribute('aria-checked', idx === i ? 'true' : 'false');
+      if (idx === q.correct) btn.classList.add('is-correct');
+      else if (idx === i) btn.classList.add('is-wrong');
+      btn.disabled = true;
+    });
+
+    const fb = root.querySelector('#quiz-feedback');
+    fb.hidden = false;
+    fb.innerHTML = (i === q.correct ? '<strong>Correct.</strong> ' : '<strong>Not quite.</strong> ') + q.explain;
+
+    root.querySelector('#quiz-next').disabled = false;
+  }
+
+  function onNext() {
+    const q = QUESTIONS[state.index];
+    state.answers.push({ pillar: q.pillar, correct: state.selected === q.correct });
+    state.selected = null;
+    state.index += 1;
+    render();
+  }
+
+  function renderResult() {
+    const total = state.answers.length;
+    const correct = state.answers.filter((a) => a.correct).length;
+    const pct = Math.round((correct / total) * 100);
+
+    const byPillar = { safety: { c: 0, t: 0 }, sustainability: { c: 0, t: 0 }, ethics: { c: 0, t: 0 } };
+    state.answers.forEach((a) => {
+      byPillar[a.pillar].t += 1;
+      if (a.correct) byPillar[a.pillar].c += 1;
+    });
+
+    let verdict;
+    if (pct >= 87) verdict = "Excellent — you could comfortably explain VCASSE's three pillars to a friend.";
+    else if (pct >= 62) verdict = "Solid grounding. A few gaps to fill in with our publications.";
+    else if (pct >= 37) verdict = "Good start. Our plain-language briefs are written exactly for this stage.";
+    else verdict = "Welcome — start with our 'About' page and one publication from each pillar.";
+
+    root.innerHTML = `
+      <div class="quiz-result">
+        <p class="example-hero-kicker" style="margin-bottom:8px;">Your score</p>
+        <div class="quiz-result-score">${correct} / ${total}</div>
+        <p style="color:var(--text-muted);margin-top:8px;">${pct}% correct overall</p>
+
+        <div class="quiz-result-pillars">
+          ${['safety', 'sustainability', 'ethics'].map((p) => `
+            <div class="quiz-pillar-stat">
+              <div class="quiz-pillar-stat-value">${byPillar[p].c}/${byPillar[p].t}</div>
+              <div class="quiz-pillar-stat-label">${PILLAR_LABEL[p]}</div>
+            </div>
+          `).join('')}
+        </div>
+
+        <p style="font-family:var(--font-serif);font-size:1.1rem;font-style:italic;color:var(--text-dark);margin:18px 0 26px;">${verdict}</p>
+
+        <div class="quiz-controls" style="justify-content:center;">
+          <button type="button" class="btn btn-secondary" id="quiz-restart">Take it again</button>
+          <a class="btn btn-primary" href="../dev/publications.html">Read VCASSE publications</a>
+        </div>
+      </div>
+    `;
+
+    root.querySelector('#quiz-restart').addEventListener('click', () => {
+      state.index = 0;
+      state.selected = null;
+      state.answers = [];
+      render();
+    });
+  }
+
+  render();
+})();

--- a/examples/policy-tracker.html
+++ b/examples/policy-tracker.html
@@ -30,7 +30,7 @@
       <p class="example-hero-lede">
         VCASSE talks a lot about transparency. This page is a sketch of what
         practising it looks like: every brief we have authored, what stage it is
-        at in the policy process, and which level of government it is aimed at.
+        at, who leads it, and the dated history of how it got there.
       </p>
     </div>
   </header>
@@ -41,17 +41,55 @@
       <div class="tracker-stats" id="tracker-stats"></div>
 
       <section class="panel">
-        <h2 class="panel-title">Active and recent briefs</h2>
-        <p class="panel-sub">Filter to see only one pillar.</p>
+        <div class="tracker-toolbar">
+          <div class="tracker-search-wrap">
+            <svg class="tracker-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.3-4.3"/></svg>
+            <input type="search" id="tracker-search" class="tracker-search" placeholder="Search briefs by title, target, or lead author">
+          </div>
 
-        <div class="glossary-filters" id="tracker-filters" style="margin-bottom:22px;">
-          <button class="glossary-filter is-active" data-pillar="all" type="button">All briefs</button>
-          <button class="glossary-filter" data-pillar="safety" type="button">Safety</button>
-          <button class="glossary-filter" data-pillar="sustainability" type="button">Sustainability</button>
-          <button class="glossary-filter" data-pillar="ethics" type="button">Ethics</button>
+          <div class="tracker-toolbar-row">
+            <select id="tracker-sort" class="calc-select tracker-select" aria-label="Sort">
+              <option value="recent" selected>Most recently updated</option>
+              <option value="oldest">Oldest first</option>
+              <option value="stage-desc">Furthest along</option>
+              <option value="stage-asc">Earliest stage</option>
+              <option value="title">Title (A–Z)</option>
+            </select>
+
+            <div class="tracker-view-toggle" role="radiogroup" aria-label="View">
+              <button type="button" data-view="list" class="is-active" aria-pressed="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
+                List
+              </button>
+              <button type="button" data-view="kanban" aria-pressed="false">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="18" rx="1"/><rect x="14" y="3" width="7" height="11" rx="1"/></svg>
+                Stage view
+              </button>
+            </div>
+          </div>
         </div>
 
-        <div class="tracker-list" id="tracker-list"></div>
+        <div class="tracker-filters">
+          <div class="glossary-filters" role="tablist" aria-label="Filter by pillar">
+            <button class="glossary-filter is-active" data-pillar="all" type="button">All pillars</button>
+            <button class="glossary-filter" data-pillar="safety" type="button">Safety</button>
+            <button class="glossary-filter" data-pillar="sustainability" type="button">Sustainability</button>
+            <button class="glossary-filter" data-pillar="ethics" type="button">Ethics</button>
+          </div>
+
+          <div class="glossary-filters" role="tablist" aria-label="Filter by government level">
+            <button class="glossary-filter glossary-filter--level is-active" data-gov="all" type="button">All levels</button>
+            <button class="glossary-filter glossary-filter--level" data-gov="city" type="button">City</button>
+            <button class="glossary-filter glossary-filter--level" data-gov="province" type="button">Province</button>
+            <button class="glossary-filter glossary-filter--level" data-gov="federal" type="button">Federal</button>
+          </div>
+        </div>
+
+        <p class="tracker-count" id="tracker-count"></p>
+
+        <div class="tracker-list" id="tracker-list" hidden></div>
+        <div class="tracker-kanban" id="tracker-kanban" hidden></div>
+        <div class="qw-empty" id="tracker-empty" hidden>No briefs match these filters.</div>
       </section>
 
       <p class="example-footnote">

--- a/examples/policy-tracker.html
+++ b/examples/policy-tracker.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Policy Brief Tracker — VCASSE</title>
+  <link rel="stylesheet" href="css/examples.css">
+  <link rel="icon" type="image/svg+xml" href="../dev/img/logo.svg">
+</head>
+<body>
+
+  <nav class="examples-nav">
+    <div class="container">
+      <a href="../dev/index.html" class="examples-nav-brand">
+        <span class="examples-nav-brand-mark">V</span>
+        <span>VCASSE</span>
+      </a>
+      <span class="examples-nav-tag">Widget · Transparency</span>
+      <a href="index.html" class="examples-nav-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        All widgets
+      </a>
+    </div>
+  </nav>
+
+  <header class="example-hero">
+    <div class="container">
+      <p class="example-hero-kicker">Policy Brief Tracker</p>
+      <h1 class="example-hero-title">Every brief we've written, and <em>where it stands.</em></h1>
+      <p class="example-hero-lede">
+        VCASSE talks a lot about transparency. This page is a sketch of what
+        practising it looks like: every brief we have authored, what stage it is
+        at in the policy process, and which level of government it is aimed at.
+      </p>
+    </div>
+  </header>
+
+  <main class="example-section">
+    <div class="container">
+
+      <div class="tracker-stats" id="tracker-stats"></div>
+
+      <section class="panel">
+        <h2 class="panel-title">Active and recent briefs</h2>
+        <p class="panel-sub">Filter to see only one pillar.</p>
+
+        <div class="glossary-filters" id="tracker-filters" style="margin-bottom:22px;">
+          <button class="glossary-filter is-active" data-pillar="all" type="button">All briefs</button>
+          <button class="glossary-filter" data-pillar="safety" type="button">Safety</button>
+          <button class="glossary-filter" data-pillar="sustainability" type="button">Sustainability</button>
+          <button class="glossary-filter" data-pillar="ethics" type="button">Ethics</button>
+        </div>
+
+        <div class="tracker-list" id="tracker-list"></div>
+      </section>
+
+      <p class="example-footnote">
+        On a real production deployment this list would be sourced from a single
+        canonical CMS so the homepage, this tracker, and our annual report all
+        stay in sync. <strong>One source of truth</strong> is the simplest accountability tool we have.
+      </p>
+    </div>
+  </main>
+
+  <script src="js/policy-tracker.js"></script>
+</body>
+</html>

--- a/examples/question-wall.html
+++ b/examples/question-wall.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Community Question Wall — VCASSE</title>
+  <link rel="stylesheet" href="css/examples.css">
+  <link rel="icon" type="image/svg+xml" href="../dev/img/logo.svg">
+</head>
+<body>
+
+  <nav class="examples-nav">
+    <div class="container">
+      <a href="../dev/index.html" class="examples-nav-brand">
+        <span class="examples-nav-brand-mark">V</span>
+        <span>VCASSE</span>
+      </a>
+      <span class="examples-nav-tag">Widget · Community</span>
+      <a href="index.html" class="examples-nav-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        All widgets
+      </a>
+    </div>
+  </nav>
+
+  <header class="example-hero">
+    <div class="container">
+      <p class="example-hero-kicker">Community Question Wall</p>
+      <h1 class="example-hero-title">What should Vancouver be <em>asking about AI?</em></h1>
+      <p class="example-hero-lede">
+        Submit a question, upvote the ones that resonate. The most-supported questions
+        become discussion themes for VCASSE's quarterly public panels — so the agenda
+        is set by the city, not by a committee in a back room.
+      </p>
+    </div>
+  </header>
+
+  <main class="example-section">
+    <div class="container">
+      <section class="panel">
+
+        <h2 class="panel-title">Ask a question</h2>
+        <p class="panel-sub">Plain language is fine. Aim for one clear question per submission.</p>
+
+        <form class="qw-form" id="qw-form" autocomplete="off">
+          <textarea id="qw-text" maxlength="240" placeholder="e.g. Should the City have to disclose when an AI system is involved in a 311 decision?" required></textarea>
+
+          <div class="qw-form-row">
+            <div class="qw-form-pillars" role="radiogroup" aria-label="Pillar tag">
+              <button type="button" data-pillar="safety" class="">Safety</button>
+              <button type="button" data-pillar="sustainability" class="">Sustainability</button>
+              <button type="button" data-pillar="ethics" class="is-active">Ethics</button>
+            </div>
+            <span class="qw-counter" id="qw-counter">0 / 240</span>
+            <button type="submit" class="btn btn-primary">Post question</button>
+          </div>
+        </form>
+
+        <h2 class="panel-title" style="margin-top:8px;">Top questions this month</h2>
+        <p class="panel-sub">Sorted by votes. Click ▲ to support a question.</p>
+
+        <div class="qw-list" id="qw-list" aria-live="polite"></div>
+
+      </section>
+
+      <p class="example-footnote">
+        Demo only — votes and questions are stored in your browser's local storage,
+        not on a server. A production version would moderate submissions and
+        persist them centrally.
+      </p>
+    </div>
+  </main>
+
+  <script src="js/question-wall.js"></script>
+</body>
+</html>

--- a/examples/quiz.html
+++ b/examples/quiz.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Literacy Quiz — VCASSE</title>
+  <link rel="stylesheet" href="css/examples.css">
+  <link rel="icon" type="image/svg+xml" href="../dev/img/logo.svg">
+</head>
+<body>
+
+  <nav class="examples-nav">
+    <div class="container">
+      <a href="../dev/index.html" class="examples-nav-brand">
+        <span class="examples-nav-brand-mark">V</span>
+        <span>VCASSE</span>
+      </a>
+      <span class="examples-nav-tag">Widget · Literacy</span>
+      <a href="index.html" class="examples-nav-back">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        All widgets
+      </a>
+    </div>
+  </nav>
+
+  <header class="example-hero">
+    <div class="container">
+      <p class="example-hero-kicker">AI Literacy Quiz</p>
+      <h1 class="example-hero-title">How well do you know <em>responsible AI?</em></h1>
+      <p class="example-hero-lede">
+        Eight questions across safety, sustainability, and ethics. The quiz scores you on
+        each pillar so you can see where your understanding is solid — and where VCASSE's
+        publications might help fill in the gaps.
+      </p>
+    </div>
+  </header>
+
+  <main class="example-section">
+    <div class="container">
+      <section class="panel quiz-card" id="quiz-root" aria-live="polite"></section>
+    </div>
+  </main>
+
+  <script src="js/quiz.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Introduces a self-contained /examples folder with five client-side widget
prototypes that align with VCASSE's three pillars and could be promoted
into the production site:

- AI Literacy Quiz: 8-question primer with per-pillar scoring
- AI Carbon Footprint Calculator: estimates weekly energy/water/CO2 from
  AI usage habits, with everyday equivalents
- Plain-Language AI Glossary: search + pillar-filter terminology library
- Policy Brief Tracker: visual roadmap of briefs through the policy
  pipeline (Draft -> Review -> Submitted -> Adopted)
- Community Question Wall: residents submit and upvote questions about
  AI ethics; persisted in localStorage

All widgets share examples/css/examples.css, which mirrors the design
tokens used in dev/css/styles.css so the prototypes sit visually flush
with the live site. examples/index.html links the five demos.