### PR TITLE
Refine about page lede and remove outdated colophon meta copy

### DIFF
--- a/dev/about.html
+++ b/dev/about.html
@@ -53,9 +53,9 @@
         <span class="serif-emphasis">Constitution.</span>
       </h1>
       <p class="manifesto-lede">
-        Our founding document: the mission, vision, and values that anchor
+        <em>Our founding document: the mission, vision, and values that anchor
         VCASSE. The standard we hold ourselves to, in writing, and the
-        standard we invite Vancouver to hold us to.
+        standard we invite Vancouver to hold us to.</em>
       </p>
     </div>
   </section>
@@ -158,10 +158,7 @@
           <p class="doc-colophon-text">
             VCASSE operates as a subsidiary program of <a href="https://oasisofchange.com" target="_blank" rel="noopener">Oasis of Change, Inc.</a>, a federal not-for-profit corporation registered in Vancouver, British Columbia, Canada.
           </p>
-          <p class="doc-colophon-text doc-colophon-text--meta">
-            Adopted 2025. This document is intended as a living standard
-            and will evolve with the work.
-          </p>
+
         </div>
       </article>
     </div>


### PR DESCRIPTION
### Motivation
- Remove an outdated colophon meta line and present the manifesto lede as emphasized text so the founding-document statement reads more clearly.

### Description
- Deleted the colophon meta paragraph from `dev/about.html` that read "Adopted 2025. This document is intended as a living standard and will evolve with the work.".
- Wrapped the manifesto lede in `dev/about.html` with `<em>...</em>` so the founding-document sentence appears in italics.

### Testing
- Ran `rg -n "Adopted 2025|Our founding document" /workspace/VCASSE/dev/about.html` to verify the targeted strings were updated or removed, and the check succeeded.
- Inspected the updated file with `nl -ba /workspace/VCASSE/dev/about.html` to confirm the `<em>` wrapper and removal of the meta paragraph, and the output matched expectations.
- Executed `git status --short` to confirm there were no unintended unstaged changes after the edit, and the command returned a clean state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7266fc7883208b4bc7ba56b10b31)