### PR TITLE
Add 'Learn AI' visual learning hub (page, styles, and interactive JS) and site navigation links

### DIFF
--- a/dev/about.html
+++ b/dev/about.html
@@ -32,6 +32,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html" class="active"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -210,6 +211,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/ai-visual-learning.html
+++ b/dev/ai-visual-learning.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Visual AI Learning Hub | VCASSE</title>
+  <meta name="description" content="Interactive, visual explainers for LLMs, neural networks, CNNs, attention, and AI safety concepts in Vancouver contexts.">
+  <link rel="stylesheet" href="css/styles.css?v=12">
+  <link rel="icon" type="image/svg+xml" href="img/logo.svg">
+</head>
+<body>
+  <nav class="navbar">
+    <div class="container">
+      <a href="index.html" class="nav-logo nav-logo-mark">
+        <img src="img/logo.svg" alt="VCASSE" width="28" height="28">
+        <span class="nav-logo-text">
+          <span>Vancouver Centre for AI Safety,</span>
+          <span>Sustainability, &amp; Ethics</span>
+        </span>
+      </a>
+      <ul class="nav-links" id="navLinks">
+        <li><a href="index.html"><span class="menu-label">Home</span></a></li>
+        <li class="nav-dropdown">
+          <button type="button" class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true" aria-controls="navResearchMenu">
+            <span class="menu-label">Research</span>
+            <svg class="nav-chevron" width="13" height="13" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <ul class="nav-dropdown-menu" id="navResearchMenu" role="menu">
+            <li role="none"><a href="safety.html" role="menuitem"><span class="menu-label">Safety</span></a></li>
+            <li role="none"><a href="sustainability.html" role="menuitem"><span class="menu-label">Sustainability</span></a></li>
+            <li role="none"><a href="ethics.html" role="menuitem"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </li>
+        <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html" class="active" aria-current="page"><span class="menu-label">Learn AI</span></a></li>
+        <li><a href="about.html"><span class="menu-label">About</span></a></li>
+        <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
+      </ul>
+      <div class="nav-actions">
+        <a href="publications.html" class="nav-cta">
+          <span class="menu-label">View publications</span>
+        </a>
+      </div>
+      <button type="button" class="nav-mobile-toggle" id="navToggle" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <section class="page-hero ai-visual-hero">
+    <div class="container">
+      <div class="page-hero-content">
+        <div class="section-label">VISUAL AI LEARNING HUB</div>
+        <h1 class="page-hero-title">AI concepts made visual, local, and practical.</h1>
+        <p class="page-hero-description">Explore animated explainers for LLMs, neural networks, CNNs, and key safety concepts—with Vancouver-focused examples and source footnotes.</p>
+      </div>
+    </div>
+  </section>
+
+  <main class="ai-visual-main">
+    <section class="ai-concepts-grid container" aria-label="AI learning concepts">
+      <article class="ai-concept-card" id="concept-llm">
+        <h2>Large Language Models (LLMs)<sup><a href="#fn-1" class="footnote-ref" id="ref-1">[1]</a></sup></h2>
+        <p>LLMs predict the next token in a sequence. They can summarize, translate, and assist with drafting by learning statistical language patterns from large datasets.</p>
+        <div class="ai-visualization" data-viz="llm" aria-label="Animated LLM token flow"></div>
+        <div class="ai-callout"><strong>Vancouver example:</strong> A multilingual city-service assistant can summarize transit notices across English, Punjabi, and Mandarin.</div>
+      </article>
+
+      <article class="ai-concept-card" id="concept-nn">
+        <h2>Neural Networks<sup><a href="#fn-2" class="footnote-ref" id="ref-2">[2]</a></sup></h2>
+        <p>Neural networks pass inputs through layers of weighted connections. During training, those weights are adjusted to reduce prediction error.</p>
+        <div class="ai-visualization" data-viz="nn" aria-label="Animated forward pass in a neural network"></div>
+        <div class="ai-callout"><strong>Vancouver example:</strong> Routing housing support requests to the right service channel based on urgency and needs.</div>
+      </article>
+
+      <article class="ai-concept-card" id="concept-cnn">
+        <h2>Convolutional Neural Networks (CNNs)<sup><a href="#fn-3" class="footnote-ref" id="ref-3">[3]</a></sup></h2>
+        <p>CNNs use learnable filters to detect visual patterns like edges, textures, and objects. They are commonly used for image classification tasks.</p>
+        <div class="ai-visualization" data-viz="cnn" aria-label="Animated CNN feature extraction"></div>
+        <div class="ai-callout"><strong>Vancouver example:</strong> Classifying shoreline photos to identify marine debris patterns over time.</div>
+      </article>
+
+      <article class="ai-concept-card" id="concept-attention">
+        <h2>Attention Mechanisms<sup><a href="#fn-4" class="footnote-ref" id="ref-4">[4]</a></sup></h2>
+        <p>Attention lets a model focus on the most relevant tokens when generating each next token, improving long-range reasoning and context handling.</p>
+        <div class="ai-visualization" data-viz="attention" aria-label="Animated attention weight visualization"></div>
+        <div class="ai-callout"><strong>Vancouver example:</strong> Question-answering over local policy documents, where key clauses need weighted focus.</div>
+      </article>
+
+      <article class="ai-concept-card" id="concept-embeddings">
+        <h2>Embeddings<sup><a href="#fn-5" class="footnote-ref" id="ref-5">[5]</a></sup></h2>
+        <p>Embeddings turn words or items into vectors so semantic similarity can be measured mathematically and searched efficiently.</p>
+        <div class="ai-visualization" data-viz="embeddings" aria-label="Animated embeddings similarity map"></div>
+        <div class="ai-callout"><strong>Vancouver example:</strong> Matching residents to training programs using meaning-based similarity, not only keyword matches.</div>
+      </article>
+
+      <article class="ai-concept-card" id="concept-safety">
+        <h2>AI Safety, Bias, and Sustainability<sup><a href="#fn-6" class="footnote-ref" id="ref-6">[6]</a></sup></h2>
+        <p>Responsible AI requires model safety checks, fairness audits, and clear awareness of environmental costs such as compute energy use.</p>
+        <div class="ai-visualization" data-viz="safety" aria-label="Animated risk and mitigation dashboard"></div>
+        <div class="ai-callout"><strong>Vancouver example:</strong> Evaluating whether public-facing AI tools are accurate across neighborhoods and language groups.</div>
+      </article>
+    </section>
+
+    <section class="ai-footnotes container" aria-labelledby="footnotes-heading">
+      <h2 id="footnotes-heading">Sources &amp; Footnotes</h2>
+      <ol>
+        <li id="fn-1"><a href="#ref-1" aria-label="Back to LLM reference">↩</a> Vaswani et al., 2017, <em>Attention Is All You Need</em>. https://arxiv.org/abs/1706.03762</li>
+        <li id="fn-2"><a href="#ref-2" aria-label="Back to Neural Network reference">↩</a> Goodfellow, Bengio, Courville, 2016, <em>Deep Learning</em>. https://www.deeplearningbook.org/</li>
+        <li id="fn-3"><a href="#ref-3" aria-label="Back to CNN reference">↩</a> LeCun et al., 1998, <em>Gradient-Based Learning Applied to Document Recognition</em>. https://ieeexplore.ieee.org/document/726791</li>
+        <li id="fn-4"><a href="#ref-4" aria-label="Back to Attention reference">↩</a> Bahdanau et al., 2014, <em>Neural Machine Translation by Jointly Learning to Align and Translate</em>. https://arxiv.org/abs/1409.0473</li>
+        <li id="fn-5"><a href="#ref-5" aria-label="Back to Embeddings reference">↩</a> Mikolov et al., 2013, <em>Efficient Estimation of Word Representations in Vector Space</em>. https://arxiv.org/abs/1301.3781</li>
+        <li id="fn-6"><a href="#ref-6" aria-label="Back to Safety reference">↩</a> OECD AI Principles (2019+) and NIST AI Risk Management Framework 1.0 (2023). https://www.nist.gov/itl/ai-risk-management-framework</li>
+      </ol>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-main">
+        <div class="footer-brand">
+          <h3>Vancouver Centre for AI Safety, Sustainability, and Ethics</h3>
+          <p>Vancouver's dedicated centre for responsible AI. We research, educate, and advocate across safety, sustainability, and ethics.</p>
+        </div>
+        <div class="footer-column">
+          <h4>Focus Areas</h4>
+          <ul>
+            <li><a href="safety.html"><span class="menu-label">Safety</span></a></li>
+            <li><a href="sustainability.html"><span class="menu-label">Sustainability</span></a></li>
+            <li><a href="ethics.html"><span class="menu-label">Ethics</span></a></li>
+          </ul>
+        </div>
+        <div class="footer-column">
+          <h4>Information</h4>
+          <ul>
+            <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+            <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
+            <li><a href="about.html"><span class="menu-label">About</span></a></li>
+            <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; <span class="footer-year"></span> VCASSE. All rights reserved.</p>
+        <div class="footer-location">Vancouver, BC, Canada</div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/ai-visual-learning.js?v=1"></script>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/dev/contact.html
+++ b/dev/contact.html
@@ -33,6 +33,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html" class="active"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -204,6 +205,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -5615,3 +5615,112 @@ body.glossary-modal-open {
     display: none;
   }
 }
+
+/* ─────────────── AI Visual Learning Hub ─────────────── */
+.ai-visual-hero {
+  background: linear-gradient(180deg, #f2f8fc 0%, #ffffff 100%);
+}
+
+.ai-visual-main {
+  padding: 40px 0 80px;
+}
+
+.ai-concepts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 22px;
+}
+
+.ai-concept-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--shadow-sm);
+  padding: 20px;
+}
+
+.ai-concept-card h2 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  color: var(--ink-strong);
+  margin-bottom: 8px;
+}
+
+.ai-concept-card p {
+  font-size: 0.98rem;
+  color: var(--text-body);
+  margin-bottom: 14px;
+}
+
+.ai-visualization {
+  height: 180px;
+  border-radius: 10px;
+  border: 1px solid rgba(13, 79, 139, 0.2);
+  background: radial-gradient(circle at 20% 15%, #eef7ff, #f8fbfe 50%, #eef3f8 100%);
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.ai-viz-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--primary);
+  position: absolute;
+  opacity: 0.8;
+}
+
+.ai-viz-line {
+  position: absolute;
+  height: 2px;
+  background: rgba(13, 79, 139, 0.3);
+  transform-origin: left center;
+}
+
+.ai-callout {
+  font-size: 0.93rem;
+  background: var(--bg-light);
+  border-left: 3px solid var(--primary);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.ai-footnotes {
+  margin-top: 30px;
+  padding-top: 14px;
+}
+
+.ai-footnotes h2 {
+  font-family: var(--font-display);
+  margin-bottom: 12px;
+}
+
+.ai-footnotes ol {
+  padding-left: 20px;
+  display: grid;
+  gap: 10px;
+}
+
+.ai-footnotes li {
+  background: #fbfdff;
+  border: 1px solid rgba(13, 79, 139, 0.16);
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.footnote-ref {
+  font-size: 0.8em;
+  color: var(--primary);
+}
+
+.footnote-hit {
+  box-shadow: 0 0 0 3px rgba(108, 180, 228, 0.4);
+  transition: box-shadow 0.3s ease;
+}
+
+@media (max-width: 768px) {
+  .ai-concepts-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/dev/ethics.html
+++ b/dev/ethics.html
@@ -33,6 +33,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -171,6 +172,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/events-archive.html
+++ b/dev/events-archive.html
@@ -169,6 +169,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/events.html
+++ b/dev/events.html
@@ -101,6 +101,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/glossary.html
+++ b/dev/glossary.html
@@ -32,6 +32,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -153,6 +154,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/index.html
+++ b/dev/index.html
@@ -34,6 +34,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -483,6 +484,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/js/ai-visual-learning.js
+++ b/dev/js/ai-visual-learning.js
@@ -1,0 +1,163 @@
+(function () {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initFootnoteHighlight();
+    document.querySelectorAll('.ai-visualization').forEach((el) => {
+      const type = el.getAttribute('data-viz');
+      if (type === 'llm') drawTokenFlow(el);
+      if (type === 'nn') drawNeuralNet(el);
+      if (type === 'cnn') drawCnnGrid(el);
+      if (type === 'attention') drawAttention(el);
+      if (type === 'embeddings') drawEmbeddings(el);
+      if (type === 'safety') drawSafetyGauge(el);
+    });
+  });
+
+  function initFootnoteHighlight() {
+    document.querySelectorAll('.footnote-ref').forEach((ref) => {
+      ref.addEventListener('click', () => {
+        const id = ref.getAttribute('href');
+        if (!id) return;
+        requestAnimationFrame(() => {
+          const target = document.querySelector(id);
+          if (!target) return;
+          target.classList.add('footnote-hit');
+          setTimeout(() => target.classList.remove('footnote-hit'), 1200);
+        });
+      });
+    });
+  }
+
+  function dot(parent, x, y, cls = 'ai-viz-dot') {
+    const n = document.createElement('span');
+    n.className = cls;
+    n.style.left = `${x}%`;
+    n.style.top = `${y}%`;
+    parent.appendChild(n);
+    return n;
+  }
+
+  function line(parent, x, y, width, deg) {
+    const n = document.createElement('span');
+    n.className = 'ai-viz-line';
+    n.style.left = `${x}%`;
+    n.style.top = `${y}%`;
+    n.style.width = `${width}%`;
+    n.style.transform = `rotate(${deg}deg)`;
+    parent.appendChild(n);
+  }
+
+  function pulse(el, delay = 0) {
+    let active = false;
+    setInterval(() => {
+      active = !active;
+      el.style.transform = active ? 'scale(1.4)' : 'scale(1)';
+      el.style.opacity = active ? '1' : '0.7';
+    }, 900 + delay);
+  }
+
+  function drawTokenFlow(el) {
+    const dots = [dot(el, 8, 40), dot(el, 27, 40), dot(el, 46, 40), dot(el, 65, 40), dot(el, 84, 40)];
+    dots.slice(0, -1).forEach((d, i) => line(el, 11 + i * 19, 45, 18, 0));
+    dots.forEach((d, i) => pulse(d, i * 70));
+  }
+
+  function drawNeuralNet(el) {
+    const left = [20, 40, 60, 80].map((y) => dot(el, 12, y));
+    const mid = [25, 50, 75].map((y) => dot(el, 48, y));
+    const right = [35, 65].map((y) => dot(el, 82, y));
+    left.forEach((l) => mid.forEach((m) => line(el, 15, parseFloat(l.style.top) + 3, 34, (parseFloat(m.style.top) - parseFloat(l.style.top)) * 0.35)));
+    mid.forEach((m) => right.forEach((r) => line(el, 51, parseFloat(m.style.top) + 3, 29, (parseFloat(r.style.top) - parseFloat(m.style.top)) * 0.45)));
+    [...left, ...mid, ...right].forEach((d, i) => pulse(d, i * 50));
+  }
+
+  function drawCnnGrid(el) {
+    for (let r = 0; r < 5; r++) {
+      for (let c = 0; c < 5; c++) {
+        const b = document.createElement('span');
+        b.style.position = 'absolute';
+        b.style.left = `${12 + c * 11}%`;
+        b.style.top = `${18 + r * 13}%`;
+        b.style.width = '9%';
+        b.style.height = '10%';
+        b.style.background = `rgba(13,79,139,${0.12 + ((r + c) % 4) * 0.12})`;
+        b.style.borderRadius = '2px';
+        el.appendChild(b);
+      }
+    }
+    const filter = document.createElement('span');
+    filter.style.position = 'absolute';
+    filter.style.left = '12%';
+    filter.style.top = '18%';
+    filter.style.width = '31%';
+    filter.style.height = '34%';
+    filter.style.border = '2px solid var(--primary-light)';
+    filter.style.borderRadius = '6px';
+    el.appendChild(filter);
+
+    let x = 12;
+    setInterval(() => {
+      x = x > 56 ? 12 : x + 11;
+      filter.style.left = `${x}%`;
+    }, 700);
+  }
+
+  function drawAttention(el) {
+    const base = [12, 28, 44, 60, 76].map((x) => dot(el, x, 70));
+    base.forEach((d, i) => {
+      const l = document.createElement('span');
+      l.className = 'ai-viz-line';
+      l.style.left = '44%';
+      l.style.top = '35%';
+      l.style.width = `${18 + i * 4}%`;
+      l.style.transform = `rotate(${-35 + i * 18}deg)`;
+      l.style.opacity = `${0.2 + i * 0.13}`;
+      el.appendChild(l);
+    });
+    dot(el, 46, 30);
+    base.forEach((d, i) => pulse(d, i * 60));
+  }
+
+  function drawEmbeddings(el) {
+    for (let i = 0; i < 18; i++) {
+      const d = dot(el, 8 + Math.random() * 84, 12 + Math.random() * 74);
+      d.style.background = i < 9 ? '#0d4f8b' : '#1f8a6b';
+      d.style.width = '10px';
+      d.style.height = '10px';
+    }
+  }
+
+  function drawSafetyGauge(el) {
+    const bars = ['Bias', 'Safety', 'Energy'].map((_, i) => {
+      const wrap = document.createElement('div');
+      wrap.style.position = 'absolute';
+      wrap.style.left = `${12 + i * 28}%`;
+      wrap.style.bottom = '14%';
+      wrap.style.width = '18%';
+      wrap.style.height = '60%';
+      wrap.style.border = '1px solid rgba(13,79,139,0.2)';
+      wrap.style.borderRadius = '8px';
+      const fill = document.createElement('span');
+      fill.style.position = 'absolute';
+      fill.style.left = '0';
+      fill.style.bottom = '0';
+      fill.style.width = '100%';
+      fill.style.height = '35%';
+      fill.style.background = i === 2 ? '#8a4a8a' : '#0d4f8b';
+      fill.style.opacity = '0.75';
+      wrap.appendChild(fill);
+      el.appendChild(wrap);
+      return fill;
+    });
+
+    let tick = 0;
+    setInterval(() => {
+      tick += 1;
+      bars.forEach((bar, i) => {
+        const height = 28 + ((tick * (i + 1) * 7) % 48);
+        bar.style.height = `${height}%`;
+      });
+    }, 650);
+  }
+})();

--- a/dev/policy-tracker.html
+++ b/dev/policy-tracker.html
@@ -32,6 +32,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -150,6 +151,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/privacy.html
+++ b/dev/privacy.html
@@ -32,6 +32,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -149,6 +150,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/publications.html
+++ b/dev/publications.html
@@ -32,6 +32,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -155,6 +156,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/safety.html
+++ b/dev/safety.html
@@ -33,6 +33,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -167,6 +168,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/sustainability.html
+++ b/dev/sustainability.html
@@ -33,6 +33,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -167,6 +168,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>

--- a/dev/terms.html
+++ b/dev/terms.html
@@ -32,6 +32,7 @@
           </ul>
         </li>
         <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
         <li><a href="about.html"><span class="menu-label">About</span></a></li>
         <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
       </ul>
@@ -134,6 +135,7 @@
           <h4>Information</h4>
           <ul>
             <li><a href="events.html"><span class="menu-label">Events</span></a></li>
+        <li><a href="ai-visual-learning.html"><span class="menu-label">Learn AI</span></a></li>
             <li><a href="about.html"><span class="menu-label">About</span></a></li>
             <li><a href="contact.html"><span class="menu-label">Contact</span></a></li>
             <li><a href="privacy.html"><span class="menu-label">Privacy Policy</span></a></li>


### PR DESCRIPTION
### Motivation
- Provide a public, visual learning resource about core AI concepts (LLMs, neural nets, CNNs, attention, embeddings, safety) to accompany VCASSE content. 
- Surface the new learning hub prominently by adding a `Learn AI` entry to site navigation and footers so visitors can discover the resource. 
- Ship interactive, lightweight visualizations to make abstract concepts more accessible to local audiences. 

### Description
- Added a new page `dev/ai-visual-learning.html` that implements the Visual AI Learning Hub content and footnoted sources. 
- Introduced interactive visuals via a new script `dev/js/ai-visual-learning.js` which creates on-page token/NN/CNN/attention/embeddings/safety visualizations and a footnote highlight helper. 
- Added styling for the hub in `dev/css/styles.css` under the `AI Visual Learning Hub` section (cards, visual containers, footnotes, responsive grid). 
- Updated multiple site pages (for example `dev/index.html`, `dev/about.html`, `dev/contact.html`, `dev/events.html`, `dev/safety.html`, `dev/sustainability.html`, `dev/ethics.html`, `dev/glossary.html`, `dev/privacy.html`, `dev/terms.html`, `dev/publications.html`, `dev/policy-tracker.html`, `dev/events-archive.html`) to include the `Learn AI` navigation and footer links so the new hub is accessible across the site. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee92e384408320809065f68ba4eb33)