### PR TITLE
Fix mobile menu sizing so company name isn't dwarfed by menu items

### DIFF
--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -2427,10 +2427,10 @@ noscript + * .fade-in,
   .nav-links > li > a,
   .nav-links > li > .nav-dropdown-trigger {
     display: flex; align-items: baseline; gap: 18px;
-    width: 100%; padding: clamp(10px, 1.8vh, 16px) 0;
+    width: 100%; padding: clamp(12px, 2.1vh, 18px) 0;
     background: transparent; border: none; cursor: pointer;
     font-family: var(--font-display);
-    font-size: clamp(1.3rem, 5.2vw, 1.75rem);
+    font-size: clamp(1.6rem, 6vw, 2.1rem);
     font-weight: 500; line-height: 1.05;
     letter-spacing: -0.5px; color: var(--mobile-menu-ink);
     text-decoration: none; text-align: left;

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -278,11 +278,16 @@ img { max-width: 100%; height: auto; display: block; }
   border-radius: 7px;
 }
 
+@media (max-width: 768px) {
+  .nav-logo { font-size: 13.5px; }
+  .nav-logo-text { height: 32px; }
+}
+
 @media (max-width: 480px) {
-  .nav-logo { font-size: 11px; }
+  .nav-logo { font-size: 12.5px; }
   .nav-logo-mark { gap: 10px; }
-  .nav-logo-text { height: 28px; }
-  .nav-logo-mark img { width: 28px; height: 28px; border-radius: 6px; }
+  .nav-logo-text { height: 30px; }
+  .nav-logo-mark img { width: 30px; height: 30px; border-radius: 6px; }
 }
 
 .nav-mobile-toggle {
@@ -2321,9 +2326,17 @@ noscript + * .fade-in,
     position: relative;
     z-index: 1225;
   }
-  body.menu-open .nav-logo { color: var(--mobile-menu-ink); transition: color 0.3s ease; }
+  body.menu-open .nav-logo {
+    color: var(--mobile-menu-ink);
+    font-size: 16px;
+    transition: color 0.3s ease, font-size 0.3s ease;
+  }
+  body.menu-open .nav-logo-text { height: 36px; gap: 2px; }
+  body.menu-open .nav-logo-mark { gap: 12px; }
+  body.menu-open .nav-logo-mark img { width: 34px; height: 34px; border-radius: 7px; }
   body.menu-open .nav-mobile-toggle span { background: var(--mobile-menu-ink); }
-  .nav-logo { transition: color 0.3s ease; }
+  .nav-logo { transition: color 0.3s ease, font-size 0.3s ease; }
+  .nav-logo-text { transition: height 0.3s ease; }
 
   .nav-mobile-toggle { display: block; margin-left: auto; z-index: 1225; }
 
@@ -2414,12 +2427,12 @@ noscript + * .fade-in,
   .nav-links > li > a,
   .nav-links > li > .nav-dropdown-trigger {
     display: flex; align-items: baseline; gap: 18px;
-    width: 100%; padding: clamp(12px, 2.2vh, 18px) 0;
+    width: 100%; padding: clamp(10px, 1.8vh, 16px) 0;
     background: transparent; border: none; cursor: pointer;
     font-family: var(--font-display);
-    font-size: clamp(1.55rem, 6.2vw, 2.15rem);
+    font-size: clamp(1.3rem, 5.2vw, 1.75rem);
     font-weight: 500; line-height: 1.05;
-    letter-spacing: -0.6px; color: var(--mobile-menu-ink);
+    letter-spacing: -0.5px; color: var(--mobile-menu-ink);
     text-decoration: none; text-align: left;
   }
 

--- a/dev/css/styles.css
+++ b/dev/css/styles.css
@@ -2489,31 +2489,28 @@ noscript + * .fade-in,
     transform: none;
     width: 100%;
     min-width: 0;
-    list-style: none; padding: 0 0 6px 34px; margin: 0;
+    list-style: none; padding: 4px 0 12px 40px; margin: 0;
     background: transparent; border: none; box-shadow: none;
     max-height: 0; overflow: hidden;
     opacity: 0; visibility: hidden;
     transition: max-height .35s ease, opacity .25s ease, visibility 0s linear .35s;
-    counter-reset: submenu;
   }
   .nav-links .nav-dropdown.is-open > .nav-dropdown-menu {
-    max-height: 220px; opacity: 1; visibility: visible;
+    max-height: 320px; opacity: 1; visibility: visible;
     transition: max-height .4s ease, opacity .3s ease .1s, visibility 0s linear 0s;
   }
-  .nav-links .nav-dropdown-menu li { counter-increment: submenu; border: none; }
+  .nav-links .nav-dropdown-menu li { border: none; }
   .nav-links .nav-dropdown-menu a {
-    display: flex; gap: 10px; padding: 4px 0;
+    display: flex; gap: 10px; padding: 8px 0;
     align-items: baseline;
     width: 100%;
     border-radius: 0;
     font-weight: 400;
-    font-family: var(--font-sans); font-size: 13px;
+    font-family: var(--font-display);
+    font-size: clamp(1.1rem, 4.4vw, 1.4rem);
+    line-height: 1.2;
+    letter-spacing: -0.2px;
     color: var(--slate-professional, #374151); text-decoration: none;
-  }
-  .nav-links .nav-dropdown-menu a::before {
-    content: counter(menu, decimal-leading-zero) "." counter(submenu);
-    font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-    font-size: 10px; color: var(--muted, #6b7280); flex: 0 0 24px;
   }
   .nav-links .nav-dropdown-menu a.active {
     background: transparent;


### PR DESCRIPTION
Mobile drawer had 25-34px menu items next to an 11-13px company name,
making "Vancouver Centre for AI Safety, Sustainability, & Ethics" look
disproportionately small. Bump the logo (especially when the menu is
open), tone down the oversized menu items, and keep the icon scaled with
the wordmark.

https://claude.ai/code/session_01D93u1zmXDPWcdzG6GTMiup